### PR TITLE
Allow usage of command aliases in help command.

### DIFF
--- a/ClemBot.Bot/bot/cogs/help_cog.py
+++ b/ClemBot.Bot/bot/cogs/help_cog.py
@@ -86,8 +86,13 @@ class HelpCog(commands.Cog):
         """
         Recursively searches the command tree to find a given command, if none found then returns None
         """
+
         if isinstance(parent, commands.Bot):
             found = None
+
+            if found := parent.get_command(command_name.lower()):
+                return found
+
             for c in parent.commands:
                 if result := self.find_command(c, command_name):
                     found = result


### PR DESCRIPTION
- Utilizes `commands.Bot.get_command(...)` to resolve #355.
- It may be possible to replace `find_command(...)` with `commands.Bot.get_command(...)` altogether, but I was unsure about that and didn't want to break anything.
- I did not test this