### PR TITLE
Switch to adding member count from all guilds for user count

### DIFF
--- a/ClemBot.Bot/bot/cogs/bot_info_cog.py
+++ b/ClemBot.Bot/bot/cogs/bot_info_cog.py
@@ -37,7 +37,7 @@ class InviteCog(commands.Cog):
         owner = self.bot.get_user(self.bot.owner_id)
 
         embed = discord.Embed(color=Colors.ClemsonOrange)
-        embed.description = f'{len(self.bot.guilds)} Guilds\n{len(self.bot.users)} Users'
+        embed.description = f'{len(self.bot.guilds)} Guilds\n{sum([g.member_count for g in self.bot.guilds])} Users'
         embed.title = f'{self.bot.user.name}#{self.bot.user.discriminator}'
         embed.add_field(name='Owner', value=owner.mention, inline=False)
         embed.add_field(name='Website', value='[Link!](https://clembot.io)')


### PR DESCRIPTION
- Switch to adding member count from all guilds for user count, instead of taking the length of the user cache.
- Slightly more accurate, but the number could be inflated. In the future, we should fetch the member ids of each server from either ClemBot API or the Discord API, put them in a set, and use the length of that set.