### PR TITLE
Moderation Service: Error Fix for Failing to Mute in Threads

### DIFF
--- a/ClemBot.Bot/bot/services/moderation_service.py
+++ b/ClemBot.Bot/bot/services/moderation_service.py
@@ -140,6 +140,9 @@ class ModerationService(BaseService):
                                       connect=False,
                                       stream=False,
                                       send_messages=False,
+                                      send_messages_in_threads=False,
+                                      create_public_threads=False,
+                                      create_private_threads=False,
                                       send_tts_messages=False,
                                       add_reactions=False)
 


### PR DESCRIPTION
Fixed issue where muted users could still create threads and send messages in new threads.