### PR TITLE
Add ping command and healthcheck ping endpoint

### DIFF
--- a/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ClemBot.Api.Core.Features.HealthCheck;
+
+[ApiController]
+[Route("api")]
+public class HealthCheckController : ControllerBase
+{
+    [HttpGet("[controller]/ping")]
+    public IActionResult Ping() => Ok("pong!");
+}

--- a/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
@@ -7,5 +7,6 @@ namespace ClemBot.Api.Core.Features.HealthCheck;
 public class HealthCheckController : ControllerBase
 {
     [HttpGet("[controller]/ping")]
+    [BotMasterAuthorize]
     public IActionResult Ping() => Ok("pong!");
 }

--- a/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/HealthCheck/HealthCheckController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using ClemBot.Api.Common.Security.Policies.BotMaster;
+using Microsoft.AspNetCore.Mvc;
 
 namespace ClemBot.Api.Core.Features.HealthCheck;
 

--- a/ClemBot.Bot/bot/api/__init__.py
+++ b/ClemBot.Bot/bot/api/__init__.py
@@ -13,4 +13,5 @@ __all__ = ['guild_route',
            'commands_route',
            'thread_route',
            'slots_score_route'
+           'health_check_route'
            ]

--- a/ClemBot.Bot/bot/api/__init__.py
+++ b/ClemBot.Bot/bot/api/__init__.py
@@ -12,6 +12,6 @@ __all__ = ['guild_route',
            'claim_route',
            'commands_route',
            'thread_route',
-           'slots_score_route'
+           'slots_score_route',
            'health_check_route'
            ]

--- a/ClemBot.Bot/bot/api/health_check_route.py
+++ b/ClemBot.Bot/bot/api/health_check_route.py
@@ -1,0 +1,11 @@
+
+from bot.api.api_client import ApiClient
+from bot.api.base_route import BaseRoute
+
+
+class HealthCheckRoute(BaseRoute):
+    def __init__(self, api_client: ApiClient):
+        super().__init__(api_client)
+        
+    async def ping(self):
+        return await self._client.get("HealthCheck/ping")

--- a/ClemBot.Bot/bot/clem_bot.py
+++ b/ClemBot.Bot/bot/clem_bot.py
@@ -12,6 +12,7 @@ from discord.ext.commands import CommandNotFound
 
 from bot.api import *
 import bot.api as api
+from bot.api import health_check_route
 import bot.cogs as cogs
 import bot.extensions as ext
 import bot.services as services
@@ -72,8 +73,9 @@ class ClemBot(commands.Bot):
         self.moderation_route: moderation_route.ModerationRoute = None
         self.claim_route: claim_route.ClaimRoute = None
         self.commands_route: commands_route.CommandsRoute = None
-        self.thread_route: thread_route.ThreadsRoute = None
+        self.thread_route: thread_route.ThreadRoute = None
         self.slots_score_route: slots_score_route.SlotsScoreRoute = None
+        self.health_check_route: health_check_route.HealthCheckRoute = None
 
         self.load_cogs()
         self.active_services = {}

--- a/ClemBot.Bot/bot/cogs/ping_pong_cog.py
+++ b/ClemBot.Bot/bot/cogs/ping_pong_cog.py
@@ -6,6 +6,7 @@ import discord
 import re
 
 import discord.ext.commands as commands
+from bot.consts import Colors
 
 import bot.extensions as ext
 
@@ -15,7 +16,7 @@ class PingPongCog(commands.Cog):
         self.bot = bot
 
     @ext.command(name='ping', aliases=['pong'])
-    @ext.long_help('Shows the latency between the bot and Discord')
+    @ext.long_help('Shows the latency between the bot\'s internal components and Discord as well as ClemBot\'s API')
     @ext.short_help('shows bot latency')
     @ext.example('ping')
     async def ping(self, ctx: commands.Context) -> None:
@@ -23,8 +24,8 @@ class PingPongCog(commands.Cog):
         await self.bot.health_check_route.ping()
         clembot_api_latency = time.perf_counter() - start
 
-        embed = discord.Embed(title="ClemBot Latency :stopwatch:")
-        embed.add_field(name="Discord WS", value=f"{self.bot.latency * 1000 : 1.2f}ms")
+        embed = discord.Embed(color=Colors.ClemsonOrange, title="ClemBot Latency :stopwatch:")
+        embed.add_field(name="Discord WebSocket", value=f"{self.bot.latency * 1000 : 1.2f}ms")
         embed.add_field(name="Discord HTTP", value=":infinity:ms")
         embed.add_field(name="ClemBot API", value=f"{clembot_api_latency * 1000 : 1.2f}ms")
         embed.set_footer(text=str(ctx.author), icon_url=ctx.author.display_avatar.url)

--- a/ClemBot.Bot/bot/cogs/ping_pong_cog.py
+++ b/ClemBot.Bot/bot/cogs/ping_pong_cog.py
@@ -1,0 +1,44 @@
+import logging
+import math
+import random
+import time
+import discord
+import re
+
+import discord.ext.commands as commands
+
+import bot.extensions as ext
+
+
+class PingPongCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @ext.command(name='ping', aliases=['pong'])
+    @ext.long_help('Shows the latency between the bot and Discord')
+    @ext.short_help('shows bot latency')
+    @ext.example('ping')
+    async def ping(self, ctx: commands.Context) -> None:
+        start = time.perf_counter()
+        await self.bot.health_check_route.ping()
+        clembot_api_latency = time.perf_counter() - start
+
+        embed = discord.Embed(title="ClemBot Latency :stopwatch:")
+        embed.add_field(name="Discord WS", value=f"{self.bot.latency * 1000 : 1.2f}ms")
+        embed.add_field(name="Discord HTTP", value=":infinity:ms")
+        embed.add_field(name="ClemBot API", value=f"{clembot_api_latency * 1000 : 1.2f}ms")
+        embed.set_footer(text=str(ctx.author), icon_url=ctx.author.display_avatar.url)
+
+        start = time.perf_counter()
+
+        sent_message = await ctx.send(embed=embed)
+
+        discord_http_latency = (time.perf_counter() - start) * 1000
+
+        embed.remove_field(1)
+        embed.insert_field_at(1, name="Discord HTTP", value=f"{discord_http_latency : 1.2f}ms")
+
+        await sent_message.edit(embed=embed)
+
+def setup(bot):
+    bot.add_cog(PingPongCog(bot))


### PR DESCRIPTION
- Adds healthcheck controller with ping endpoint
- Adds a ping command in the ping pong cog that shows the latency between the Discord WebSocket gateway and the bot, the latency between Discord's edit message endpoint and the bot, and the latency between ClemBot API and the bot.
- Resolves #548

![image](https://user-images.githubusercontent.com/38477514/155864779-53a7d29c-815a-4ebf-b257-51103655bcfd.png)
