### PR TITLE
Fix help command not recognizing different cased commands

### DIFF
--- a/ClemBot.Bot/bot/cogs/help_cog.py
+++ b/ClemBot.Bot/bot/cogs/help_cog.py
@@ -23,7 +23,7 @@ class HelpCog(commands.Cog):
     async def help(self, ctx, *, command_name=None):
 
         if command_name:
-            command = self.find_command(self.bot, command_name)
+            command = self.find_command(self.bot, command_name.lower())
             if isinstance(command, ext.ClemBotCommand):
                 await self.send_command_help(ctx, command)
             elif isinstance(command, ext.ClemBotGroup):


### PR DESCRIPTION
<img width="543" alt="image" src="https://user-images.githubusercontent.com/10692069/159096466-0d4564e7-9041-4781-9a68-943952a904e2.png">
