### PR TITLE
Python 3.10.4 Update + triviacog.py + Minor changes around pagination service 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ This is a guide on how to develop and contribute to this project
 ## Dependencies
 Make sure you can run these commands and install them if not present.
 ### ClemBot.Bot
-* Python 3.8 [Link](https://www.python.org/downloads/release/python-380/)
+* Python 3.10.4 [Link](https://www.python.org/downloads/release/python-3104/)
 * pip3 (packaged as python3-pip) 
 * A python IDE/Text Editor: Anything will work but people generally use Visual Studio Code [Link](https://code.visualstudio.com/) or Jetbrains Pycharm [Link](https://www.jetbrains.com/pycharm/)
 

--- a/ClemBot.Bot/Dockerfile
+++ b/ClemBot.Bot/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim-buster
+FROM python:3.10.4-slim-buster
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/ClemBot.Bot/bot/cogs/translate_cog.py
+++ b/ClemBot.Bot/bot/cogs/translate_cog.py
@@ -20,9 +20,9 @@ class TranslateCog(commands.Cog):
 
     @ext.group(case_insensitive=True, invoke_without_command=True)
     @ext.long_help(
-        'Allows you to translate words or sentences by either specifying both the input and output language with the text to translate, or just the output language and the text to translate. run \'translate languages\' to see available languages')
-    @ext.short_help('Translates words or phrases between two languages')
-    @ext.example(('translate en spanish Hello', 'translate german Hello', 'translate languages', 'translate Spanish German Como estas?'))
+        'Allows you to translate words or sentences by entering an output language and autodetecting the language you input. run \'translate languages\' to see available languages')
+    @ext.short_help('Translates words or phrases using autodetect.')
+    @ext.example(('translate spanish Hello', 'translate german Hello', 'translate languages', 'translate German Como estas?', "!translate <outputlang> <text>"))
     async def translate(self, ctx, *input: str):
 
         if len(input) < 2:
@@ -49,8 +49,8 @@ class TranslateCog(commands.Cog):
                                          channel=ctx.channel)
         return
     @translate.command(aliases=['m'])
-    @ext.long_help('Manually specifies an output language to translate too')
-    @ext.short_help('Specify an output language')
+    @ext.long_help('Manually specifies an input langauge !translate m <outputlang> <input language> <text>')
+    @ext.short_help('Specify an output language + the language you entered to translate')
     @ext.example('translate m or translate manual')
     async def manual(self, ctx, *input: str):
 
@@ -114,7 +114,7 @@ class TranslateCog(commands.Cog):
             response = json.loads(await resp.text())
 
         embed = discord.Embed(title='Translate', color=Colors.ClemsonOrange)
-        name = 'Translated to ' + LANGUAGE_SHORT_CODE_TO_NAME[response[0]['detectedLanguage']['language']]
+        name = 'Translated from: ' + LANGUAGE_SHORT_CODE_TO_NAME[response[0]['detectedLanguage']['language']]
         embed.add_field(name='Confidence Level:', value=response[0]['detectedLanguage']['score'], inline=True)
         embed.add_field(name=name, value=response[0]['translations'][0]['text'], inline=False)
         await ctx.send(embed=embed)
@@ -156,11 +156,11 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Azerbaijani":"az",      
             "Bangla":"bn",      
             "Bashkir":"ba",      
-            "Bosnian-(Latin)":"bs",      
+            "Bosnian-Latin":"bs",      
             "Bulgarian":"bg",      
-            "Cantonese-(Traditional)":"yue",        
+            "Cantonese-Traditional":"yue",        
             "Catalan":"ca",      
-            "Chinese-(Literary)":"lzh",        
+            "Chinese-Literary":"lzh",        
             "Chinese-Simplified":"zh-Hans",          
             "Chinese-Traditional":"zh-Hant",          
             "Croatian":"hr",      
@@ -175,7 +175,7 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Filipino":"fil",        
             "Finnish":"fi",      
             "French":"fr",      
-            "French-(Canada)":"fr-ca",        
+            "French-Canada":"fr-ca",        
             "Georgian":"ka",      
             "German":"de",      
             "Greek":"el",      
@@ -189,7 +189,7 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Indonesian":"id",      
             "Inuinnaqtun":"ikt",        
             "Inuktitut":"iu",      
-            "Inuktitut-(Latin)":"iu-Latn",          
+            "Inuktitut-Latin":"iu-Latn",          
             "Irish":"ga",      
             "Italian":"it",      
             "Japanese":"ja",      
@@ -197,23 +197,23 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Kazakh":"kk",      
             "Khmer":"km",      
             "Klingon":"tlh-Lat",          
-            "Klingon-(plqaD)":"tlh-Piq",          
+            "Klingon-plqaD":"tlh-Piq",          
             "Korean":"ko",      
-            "Kurdish-(Central)  ":"ku",      
-            "Kurdish-(Northern)":"kmr",        
+            "Kurdish-Central":"ku",      
+            "Kurdish-Northern":"kmr",        
             "Kyrgyz":"ky",      
             "Lao":"lo",      
             "Latvian":"lv",      
             "Lithuanian":"lt",      
             "Macedonian":"mk",      
             "Malagasy":"mg",      
-            "Malay ":"ms",      
+            "Malay":"ms",      
             "Malayalam":"ml",      
             "Maltese":"mt",      
             "Maori":"mi",      
             "Marathi":"mr",      
-            "Mongolian-(Cyrillic)":"mn-Cyrl",          
-            "Mongolian-(Traditional)":"mn-Mong",          
+            "Mongolian-Cyrillic":"mn-Cyrl",          
+            "Mongolian-Traditional":"mn-Mong",          
             "Myanmar":"my",      
             "Nepali":"ne",      
             "Norwegian":"nb",      
@@ -221,15 +221,15 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Pashto":"ps",      
             "Persian ":"fa",      
             "Polish":"pl",      
-            "Portuguese (Brazil)":"pt",      
-            "Portuguese (Portugal)":"pt-pt",        
+            "Portuguese-Brazil":"pt",      
+            "Portuguese-Portugal":"pt-pt",        
             "Punjabi":"pa",      
             "Queretaro Otomi":"otq",        
             "Romanian":"ro",      
             "Russian":"ru",      
             "Samoan":"sm",      
-            "Serbian-(Cyrillic)":"sr-Cyrl",          
-            "Serbian-(Latin)":"sr-Latn",          
+            "Serbian-Cyrillic":"sr-Cyrl",          
+            "Serbian-Latin":"sr-Latn",          
             "Slovak":"sk",      
             "Slovenian":"sl",      
             "Spanish":"es",      
@@ -246,10 +246,10 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
             "Turkish":"tr",      
             "Turkmen":"tk",      
             "Ukrainian":"uk",      
-            "Upper Sorbian":"hsb",        
+            "Upper-Sorbian":"hsb",        
             "Urdu":"ur",      
             "Uyghur":"ug",      
-            "Uzbek-(Latin)":"uz",      
+            "Uzbek-Latin":"uz",      
             "Vietnamese":"vi",      
             "Welsh":"cy",      
             "Yucatec-Maya":"yua",                           

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -263,29 +263,6 @@ URL_PARAMS = {
 
 URL_BUILDER = R"https://opentdb.com/api.php?amount="
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 DEFAULT_URL = "https://opentdb.com/api.php?amount=10"
    
 

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -230,9 +230,7 @@ class TriviaCog(commands.Cog):
                   new_list_values = x.values()
                   proper_values = []
                   for b in new_list_values:
-                      print(b)
                       if isinstance(b, list):
-                            print("yes")
                             new_list = []
                             for y in b:
                               if not y.isnumeric():
@@ -246,8 +244,7 @@ class TriviaCog(commands.Cog):
                       else:
                           proper_values.append(b)
                   propervalues_size = len(proper_values)        
-                  biggest_loop = 0
-                  print(proper_values)      
+                  biggest_loop = 0   
                   for key, value in new_dictionary.items():
                         new_dictionary[key] = proper_values[biggest_loop]
                         if biggest_loop < propervalues_size:
@@ -258,7 +255,6 @@ class TriviaCog(commands.Cog):
                 dictionarysize = len(new_response['results'])
                 best_loopint = 0  
                 while best_loopint < dictionarysize:
-                      print(dictionary_list[best_loopint])
                       new_response['results'][best_loopint] = dictionary_list[best_loopint] 
                       best_loopint+=1
                 return new_response

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -74,8 +74,9 @@ class TriviaCog(commands.Cog):
     async def Url_Builder(self, functionlist, inputlength):
             max_index = inputlength-1
             url = URL_BUILDER+ str(functionlist[0])
-            for x in range(1, max_index):
-                if functionlist[x]:
+            x = 1
+            while x <= max_index:
+                 if functionlist[x]:
                      match x:
                          case 1:
                                  url+=("&category="+ str(functionlist[1]))
@@ -83,6 +84,7 @@ class TriviaCog(commands.Cog):
                                 url+=("&difficulty=" + functionlist[2])
                          case 3:
                                  url+=("&type="+functionlist[max_index])
+                 x+=1                
             return url   
                           
           

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -1,6 +1,8 @@
+import chunk
 import json
 import logging
 import threading
+from typing import Final
 from urllib import response
 import uuid
 import random
@@ -33,14 +35,14 @@ class TriviaCog(commands.Cog):
     "Use !trivia to return a random assortment of 10 trivia questions. React with emojis to submit your answer choice"    )
     @ext.short_help(
     "!trivia use !trivia m for custom arguments"    )
-    async def Trivia(self, ctx):
+    async def trivia(self, ctx):
         async with await self.session.get(DEFAULT_URL) as resp:
                 theresponse = json.loads(await resp.text())
                 correct_answers = await self.Json_Parser(ctx, theresponse)
              
         dictreturn = await self.Dict_Publisher(ctx, theresponse, correct_answers)                  
                        
-    @Trivia.command(aliases=['m'])
+    @trivia.command(aliases=['m'])
     @ext.long_help(
         "Specify arguments you want to return such as question number (max 35), category, difficulty, or question type. Use numbers for quicker specification of category by typing in the number beside the category in !help. Use 0 for unused categories!")
     @ext.short_help("!trivia m <Question Number> <category/substring/number> <Difficulty/Number> <question type>")
@@ -55,11 +57,9 @@ class TriviaCog(commands.Cog):
      while x < inputlength:
         
         appendthis = await self.Matching_Function(x, *input)
-        print(appendthis)
         FunctionParameters.append(appendthis)
         x+=1    
      url = await self.Url_Builder(FunctionParameters, inputlength)
-     print(url)
      async with await self.session.get(url) as resp:  
             response = json.loads(await resp.text())
             correct_answers = await self.Json_Parser(ctx, response)
@@ -71,6 +71,53 @@ class TriviaCog(commands.Cog):
      theembed = await self.Dict_Publisher(ctx, response, correct_answers)       
 
      return
+    @trivia.command(aliases=['help'])
+    @ext.long_help(
+                    "Lists the categories, difficulty, and type of questions. Useful for finding the index of categories!")
+    @ext.short_help(
+                "Use this to find the category you want!" )     
+    @ext.example(
+            "!trivia help" )                        
+    async def List_Help(self, ctx):
+        embed_list = []
+        Final_Page = []
+        Category_Generator = helper_fixer(CATEGORYLIST)
+        for x in Category_Generator:
+            embed_list.append(x)
+        sizeofcategory = len(embed_list)
+        x = 0
+        while x < sizeofcategory:
+            Category_embed = discord.Embed(title="Category List:", color = Colors.ClemsonOrange)
+            Category_embed.add_field(name="Index:",value=embed_list[x])
+            Final_Page.append(Category_embed)
+            x+=1
+        Difficulty_Generator = helper_fixer(DIFFICULTY)    
+        for i in Difficulty_Generator:
+            embed_list.append(i)
+        new_insertion = len(embed_list)
+        while sizeofcategory < new_insertion:
+            Difficulty_embed = discord.Embed(title="Difficulty List:", color = Colors.ClemsonOrange)
+            Difficulty_embed.add_field(name="Index:",value=embed_list[sizeofcategory])
+            Final_Page.append(Difficulty_embed)
+            sizeofcategory+=1
+        Question_Generator = helper_fixer(QUESTIONTYPE)
+        for i in Question_Generator:
+            embed_list.append(i)
+        last_size = len(embed_list)
+        while new_insertion < last_size:
+            Type_embed = discord.Embed(title="Question Type:", color = Colors.ClemsonOrange)
+            Type_embed.add_field(name="Index:",value=embed_list[new_insertion])
+            Final_Page.append(Type_embed)
+            new_insertion+=1 
+        await self.bot.messenger.publish(Events.on_set_pageable_embed,
+                                         pages=Final_Page,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360,
+                                        )
+       
+         
+        return 
     async def Url_Builder(self, functionlist, inputlength):
             max_index = inputlength-1
             url = URL_BUILDER+ str(functionlist[0])
@@ -86,9 +133,7 @@ class TriviaCog(commands.Cog):
                                  url+=("&type="+functionlist[max_index])
                  x+=1                
             return url   
-                          
-          
-            
+                            
     async def Matching_Function(self, case, *input:str):
      
      match case:
@@ -150,17 +195,7 @@ class TriviaCog(commands.Cog):
                  else:
                         raise UserInputError("Question type invalid.")    
      return                      
-    async def List_Help(self):
-        embed_list = []
-        embed_list.append(self.helper_fixer(CATEGORYLIST))
-        embed_list.append(self.helper_fixer(DIFFICULTY))
-        embed_list.append(self.helper_fixer(QUESTIONTYPE))
-        embed = discord.Embed(title= "Help Page:",
-         descripton="Help Page:",
-         color=Colors.ClemsonOrange)
-        embed.addfield(name="Categories:", value=CATEGORYLIST)
-         
-        return
+  
     async def Json_Parser(self,ctx, dictionary):
         Correct_Answers= []
         for x in dictionary['results']:
@@ -179,7 +214,7 @@ class TriviaCog(commands.Cog):
              random.shuffle(Answers_List)
              List_Index.append(Answers_List.index(Right_Answer))  
              x+=1   
-             embed = discord.Embed(title= "Your Trivia Question #"+str(x)+":",
+             embed = discord.Embed(title= "Question #"+str(x)+":",
              color=Colors.ClemsonOrange)
              embed.add_field(name="Question:", value=bob['question'])
              embed.add_field(name="Category:", value=bob['category'])
@@ -201,27 +236,6 @@ class TriviaCog(commands.Cog):
                                          timeout=360,
                                         )
                                         
-        tester = discord.ext.commands.Paginator.pages                           
-       
-                                      
-                                                                       
-        print("yes\n\n\n\n\n")
-        def newcheck(bot):
-            return bot.author == self.bot.user.id
-        msg = await self.bot.wait_for("message", check=newcheck)                                                                   
-       # await msgembed.add_reaction('🇦')
-       # await msgembed.add_reaction('🇧')
-       # await msgembed.add_reaction('🇨')
-        #await msgembed.add_reaction('🇩')
-       
-        def check(reaction, user):
-            return user == ctx.author and ANSWER_KEY.find(str(reaction.emoji)) != -1
-            
-            
-        while Publish_Embed.is_alive():
-            
-                reaction, user  = await self.client.wait_for("reaction_add", timeout=360, check=check)
-                current_pagenumber = discord.ext.pages.Paginator.current_page
         
         return                                                                          
         
@@ -236,14 +250,15 @@ class TriviaCog(commands.Cog):
             return
    
 
-    def helper_fixer(formatthis):
-         newlist = []
-         for x in formatthis:   #Fix this+ formatting
-           newlist[x] = '\n'.append(formatthis[x]) + "     Index Of Element:"+formatthis.index([x])
-         for i in range(0, len(formatthis), CHUNK_SIZE):
-             yield newlist[i:i+CHUNK_SIZE]          
+def helper_fixer(formatthis):
 
-CHUNK_SIZE = 15
+         new_list = [f'#{formatthis.index(x)+1}.    {x}' for x in formatthis]
+         return ['\n'.join(i) for i in chunk_list(new_list, CHUNK_SIZE)]  #Decided to implement chunking. Although useless now if the category lists expands alot it will be an easy fix.
+def chunk_list(lst, n):
+ for i in range(0, len(lst), n):   
+    yield lst[i:i+n]       
+
+CHUNK_SIZE = 24
 
 ANSWER_KEY=['🇦',
             '🇧',

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -12,7 +12,9 @@ import bot.bot_secrets as bot_secrets
 import bot.extensions as ext
 from bot.consts import Colors
 from bot.messaging.events import Events
-client = discord.Client()
+
+
+
 class TriviaCog(commands.Cog):
 
     def cog_unload(self):
@@ -55,8 +57,9 @@ class TriviaCog(commands.Cog):
         first_Reaction = await thereaction
         current_page = 0
         run_once = True
+       
         while True:
-            print(current_page)
+
             if run_once:
                 current_page = await self.Parse_Reaction(first_Reaction, current_page, length, best_list[0], msg)
                 run_once = False
@@ -390,7 +393,6 @@ class TriviaCog(commands.Cog):
               
     async def Parse_Reaction(self, reaction,current_page, length, right_answer, msg):
 
-        print(str(reaction.emoji))
         if reaction.emoji == "⏮️":
             if current_page != 0:
                 current_page = 0
@@ -406,8 +408,9 @@ class TriviaCog(commands.Cog):
         if reaction.emoji in ANSWER_KEY:
             index_of = ANSWER_KEY.index(reaction.emoji)
             if right_answer[current_page] == index_of:
-                print("\n\n\n\nIt was right!")
-                await msg.add_reaction("⭐")
+                pub = discord.Embed(title="You are a star!", description="yeah!")
+                self.bot.messenger.publish(pub)
+
                 return current_page
 
         return current_page        
@@ -479,4 +482,5 @@ CATEGORYLIST_LOWER = [k.lower() for k in CATEGORYLIST]
 
 def setup(bot):
     bot.add_cog(TriviaCog(bot))
+
     

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -38,6 +38,7 @@ class TriviaCog(commands.Cog):
         async with await self.session.get(DEFAULT_URL) as resp:
                 theresponse = json.loads(await resp.text())
                 correct_answers = await self.Json_Parser(ctx, theresponse)
+             
         dictreturn = await self.Dict_Publisher(ctx, theresponse, correct_answers)                  
                        
     @Trivia.command(aliases=['m'])
@@ -58,19 +59,21 @@ class TriviaCog(commands.Cog):
         print(appendthis)
         FunctionParameters.append(appendthis)
         x+=1    
-
-     print("bob")
      url = await self.Url_Builder(FunctionParameters, inputlength)
      print(url)
      async with await self.session.get(url) as resp:  
             response = json.loads(await resp.text())
             correct_answers = await self.Json_Parser(ctx, response)
+     if response['response_code'] == 1:
+         raise Exception(
+                            "There isn't enough questions in that category. Lower your question amount or select another! Or select a different question type!")
+
+
      theembed = await self.Dict_Publisher(ctx, response, correct_answers)       
 
      return
     async def Url_Builder(self, functionlist, inputlength):
             max_index = inputlength-1
-            print(max_index)
             if functionlist[max_index]:
                     match max_index:
                         case 0:
@@ -94,7 +97,6 @@ class TriviaCog(commands.Cog):
             if input[0].isnumeric():
                 questionnumber = int(input[0])
                 if 0 < questionnumber <= 50:
-                    print(questionnumber)
                     return questionnumber    
 
             else:
@@ -112,7 +114,6 @@ class TriviaCog(commands.Cog):
             else:
                 triviacategory = input[1].lower()
                 for x in CATEGORYLIST_LOWER:
-                 print(x)
                  if x.find(triviacategory) != -1:
                      Returnthis = CATEGORYLIST_LOWER.index(x)+9
                      return Returnthis
@@ -198,10 +199,10 @@ class TriviaCog(commands.Cog):
                                          pages=cog_embeds,
                                          author=ctx.author,
                                          channel=ctx.channel,
+                                         timeout=360,
                                         )
                                         
-        tester = discord.ext.commands.Paginator.pages  
-        print(tester)                          
+        tester = discord.ext.commands.Paginator.pages                           
        
                                       
                                                                        

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -56,6 +56,7 @@ class TriviaCog(commands.Cog):
      async with await self.session.get(url=url) as resp:  
             response = json.loads(await resp.text())
             correct_answers = await self.JsonParser(response)
+     theembed = self.Dict_Publisher(response, correct_answers, response)       
 
      return
     async def Url_Builder(self, functionlist):
@@ -72,7 +73,7 @@ class TriviaCog(commands.Cog):
                         case 3:
                             url = url + "&type="+functionlist[x]             
 
-        return
+        return url
     async def Matching_Function(self, case, *input:str):
      
      match case:
@@ -176,7 +177,6 @@ class TriviaCog(commands.Cog):
             embed.addfield(name=chr(a)+":", value = iterative, inline=False)
             a=a+1
          cog_embeds.append(embed)
-        
         msgembed = await self.bot.messenger.publish(Events.on_set_pageable_embed,
                                          pages=cog_embeds,
                                          author=ctx.author,
@@ -187,37 +187,27 @@ class TriviaCog(commands.Cog):
         await msgembed.add_reaction('🇧')
         await msgembed.add_reaction('🇨')
         await msgembed.add_reaction('🇩')
-        current_pagenumber = 1
-        max_pagenumber = len(cog_embeds)
+        max_pagenumber = discord.ext.pages.Paginator.current_page
+        def check(reaction, user):
+            return user == ctx.author and ANSWER_KEY.find(str(reaction.emoji)) != -1
         while not msgembed.empty:
             
-         reaction  = await self.client.wait_for("reaction_add", timeout=360, check=check)
-         current_pagenumber = await self.On_Reaction(reaction.emoji, List_Index, msgembed, current_pagenumber, max_pagenumber)
+         reaction, user  = await self.client.wait_for("reaction_add", timeout=360, check=check)
+         current_pagenumber = discord.ext.pages.Paginator.current_page
         return msgembed
     
-
+   
     async def On_Reaction(self, ctx, reaction, rightanswer, msgembeds, current_page, max_pagenumber):
 
             if ANSWER_KEY[rightanswer[current_page]] == reaction:
                 del msgembeds[current_page] # Add something to scoreboard to give indication it was right
-            elif MOVEMENT_ARROWS.find(reaction):      
-                Index_Of = MOVEMENT_ARROWS.index(reaction)
-                match Index_Of:
-                    case 0:
-                        return current_page+1
-                    case 1:
-                        if current_page > 1:
-                            return current_page-1
-                    case 2:
-                        return max_pagenumber
-                    case 3:
-                        return 1            
+          
                 
-            return current_page
+            return
 
     def helper_fixer(formatthis):
          newlist = []
-         for x in formatthis:
+         for x in formatthis:   #Fix this+ formatting
            newlist[x] = '\n'.append(formatthis[x]) + "     Index Of Element:"+formatthis.index([x])
          for i in range(0, len(formatthis), CHUNK_SIZE):
              yield newlist[i:i+CHUNK_SIZE]          
@@ -276,15 +266,15 @@ QUESTIONTYPE = [
     "bool"
 ]
 QUESTIONTYPE_LOWER = [k.lower for k in QUESTIONTYPE]
-CATEGORYLIST = ["General Knowledge", #Including this out of consistency to avoid making the offset 10 for no reason. This will be the default value.
+CATEGORYLIST = ["General-Knowledge", #Including this out of consistency to avoid making the offset 10 for no reason. This will be the default value.
                  "Books", 
                  "Film", 
                  "Music", 
-                 "Musicals & Theatres", 
+                 "Musicals&Theatres", 
                  "Television",
-                 "Video Games",
-                 "Board Games",
-                 "Science & Nature", 
+                 "Video-Games",
+                 "Board-Games",
+                 "Science&Nature", 
                  "Computers", 
                  "Mathematics", 
                  "Mythology", 
@@ -298,8 +288,8 @@ CATEGORYLIST = ["General Knowledge", #Including this out of consistency to avoid
                "Vehicles",
               "Comics",
              "Gadgets",
-            "Japanese Anime & Manga",
-           "Cartoon & Animations"]
+            "Japanese-Anime&Manga",
+           "Cartoon&Animations"]
 CATEGORYLIST_LOWER = [k.lower for k in CATEGORYLIST]
 
 def setup(bot):

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -1,9 +1,5 @@
-import chunk
 import json
 import logging
-import threading
-from typing import Final
-from urllib import response
 import uuid
 import random
 import aiohttp

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -131,6 +131,8 @@ class TriviaCog(commands.Cog):
        
          
         return 
+
+        
     async def Url_Builder(self, functionlist, inputlength):
 
             max_index = inputlength-1
@@ -149,7 +151,8 @@ class TriviaCog(commands.Cog):
                  x+=1  
 
             return url   
-                            
+
+
     async def Matching_Function(self, case, *input:str):
      
      match case:
@@ -222,42 +225,63 @@ class TriviaCog(commands.Cog):
                  else:
                         raise UserInputError(
                             "Couldn't find the question type you are looking for!.")    
-     return                      
+     return    
+
+
     async def HTML_Parser(self, new_response):
                 dictionary_list = [] #pain
+
                 for x in new_response['results']:
+
                   new_dictionary = x
                   new_list_values = x.values()
                   proper_values = []
+
                   for b in new_list_values:
+
                       if isinstance(b, list):
+
                             new_list = []
+
                             for y in b:
+
                               if not y.isnumeric():
                                  new_list.append(html.unescape(y))
                               else:
                                   new_list.append(y)
+
                             proper_values.append(new_list)             
                                   
                       elif not b.isnumeric():
+
                           proper_values.append(html.unescape(b))  # good luck maintaining this 
                       else:
                           proper_values.append(b)
+
                   propervalues_size = len(proper_values)        
                   biggest_loop = 0   
+
                   for key, value in new_dictionary.items():
+
                         new_dictionary[key] = proper_values[biggest_loop]
                         if biggest_loop < propervalues_size:
                             biggest_loop+=1
                         else:
-                            break    
+                            break  
+
                   dictionary_list.append(new_dictionary)
+
                 dictionarysize = len(new_response['results'])
                 best_loopint = 0  
+
                 while best_loopint < dictionarysize:
+
                       new_response['results'][best_loopint] = dictionary_list[best_loopint] 
                       best_loopint+=1
+
                 return new_response
+
+
     async def Json_Parser(self,ctx, dictionary):
         Correct_Answers= []
 
@@ -265,6 +289,7 @@ class TriviaCog(commands.Cog):
             Correct_Answers.append(x['correct_answer'])
 
         return Correct_Answers
+
 
     async def Dict_Publisher(self, ctx, dictionary, Correct_answers):
         x=0
@@ -304,8 +329,7 @@ class TriviaCog(commands.Cog):
         
         return                                                                          
         
-    
-   
+
     async def On_Reaction(self, ctx, reaction, rightanswer, msgembeds, current_page, max_pagenumber):
 
             if ANSWER_KEY[rightanswer[current_page]] == reaction:

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -33,12 +33,11 @@ class TriviaCog(commands.Cog):
         async with await self.session.get(DEFAULT_URL) as resp:
                 parse_text = await resp.text()
                 new_response = json.loads(parse_text)
-            
                 parsed_response = await self.HTML_Parser(new_response)                
 
-                correct_answers = await self.Json_Parser(ctx, parsed_response)  #If you're curious as to why this doesn't check response code: It's because it will never NOT have questions for the default. If it does the website is down and it will error out anyway.
+                #If you're curious as to why this doesn't check response code: It's because it will never NOT have questions for the default. If it does the website is down and it will error out anyway.
              
-        dictreturn = await self.Dict_Publisher(ctx, parsed_response, correct_answers)
+        dictreturn = await self.Dict_Publisher(ctx, parsed_response)
         return                  
                        
     @trivia.command(aliases=['m'])
@@ -66,14 +65,13 @@ class TriviaCog(commands.Cog):
      async with await self.session.get(url) as resp:  
 
             response = json.loads(await resp.text())
-            correct_answers = await self.Json_Parser(ctx, response)
 
      if response['response_code'] == 1:
          raise Exception(
                             "There isn't enough questions in that category. Lower your question amount or select another! Or select a different question type!")
 
      parsed_response = await self.HTML_Parser(response)
-     theembed = await self.Dict_Publisher(ctx, parsed_response, correct_answers)       
+     theembed = await self.Dict_Publisher(ctx, parsed_response)       
 
      return
 
@@ -132,7 +130,7 @@ class TriviaCog(commands.Cog):
          
         return 
 
-        
+
     async def Url_Builder(self, functionlist, inputlength):
 
             max_index = inputlength-1
@@ -282,16 +280,7 @@ class TriviaCog(commands.Cog):
                 return new_response
 
 
-    async def Json_Parser(self,ctx, dictionary):
-        Correct_Answers= []
-
-        for x in dictionary['results']:
-            Correct_Answers.append(x['correct_answer'])
-
-        return Correct_Answers
-
-
-    async def Dict_Publisher(self, ctx, dictionary, Correct_answers):
+    async def Dict_Publisher(self, ctx, dictionary):
         x=0
         cog_embeds = []
         List_Index = []

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -13,7 +13,6 @@ import bot.bot_secrets as bot_secrets
 import bot.extensions as ext
 from bot.consts import Colors
 from bot.messaging.events import Events
-import requests
 
 
 
@@ -74,22 +73,20 @@ class TriviaCog(commands.Cog):
      return
     async def Url_Builder(self, functionlist, inputlength):
             max_index = inputlength-1
-            if functionlist[max_index]:
-                    match max_index:
-                        case 0:
-                            url = URL_BUILDER+ str(functionlist[0])
-                            return url
-                        case 1:
-                            url = URL_BUILDER+ str(functionlist[0]) + "&category="+ str(functionlist[1])
-                            return url
-                        case 2: 
-                            url = URL_BUILDER+ str(functionlist[0])+ "&category="+ str(functionlist[1]) + "&difficulty=" + functionlist[2]
-                            return url
-                        case 3:
-                            url = URL_BUILDER + str(functionlist[0])+ "&category="+ str(functionlist[1]) + "&difficulty=" + functionlist[2]+ "&type="+functionlist[max_index]
-                            return url             
+            url = URL_BUILDER+ str(functionlist[0])
+            for x in range(1, max_index):
+                if functionlist[x]:
+                     match x:
+                         case 1:
+                                 url+=("&category="+ str(functionlist[1]))
+                         case 2: 
+                                url+=("&difficulty=" + functionlist[2])
+                         case 3:
+                                 url+=("&type="+functionlist[max_index])
+            return url   
+                          
           
-            return
+            
     async def Matching_Function(self, case, *input:str):
      
      match case:

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -17,6 +17,7 @@ from bot.messaging.events import Events
 
 
 log = logging.getLogger(__name__)
+
 class TriviaCog(commands.Cog):
 
     def cog_unload(self):
@@ -264,6 +265,7 @@ class TriviaCog(commands.Cog):
     
 
     async def HTML_Parser(self, new_response):
+
                 dictionary_list = [] #pain
 
                 for x in new_response['results']:
@@ -321,12 +323,12 @@ class TriviaCog(commands.Cog):
         x=0
         cog_embeds = []
         List_Index = []
-        for bob in dictionary['results']:
+        for create_lists in dictionary['results']:
 
              Answers_List= []   
-             Answers_List = bob['incorrect_answers']
-             Answers_List.append(bob['correct_answer'])
-             Right_Answer = bob['correct_answer']
+             Answers_List = create_lists['incorrect_answers']
+             Answers_List.append(create_lists['correct_answer'])
+             Right_Answer = create_lists['correct_answer']
 
              random.shuffle(Answers_List)
              List_Index.append(Answers_List.index(Right_Answer))  
@@ -334,8 +336,8 @@ class TriviaCog(commands.Cog):
              embed = discord.Embed(title= "Question #"+str(x)+":",
              color=Colors.ClemsonOrange)
 
-             embed.add_field(name="Question:", value=bob['question'])
-             embed.add_field(name="Category:", value=bob['category'])
+             embed.add_field(name="Question:", value=create_lists['question'])
+             embed.add_field(name="Category:", value=create_lists['category'])
 
              a = 65
              for iterative in Answers_List:
@@ -344,9 +346,11 @@ class TriviaCog(commands.Cog):
                 a=a+1
 
              cog_embeds.append(embed)
+             
         mega_list=[]
         mega_list.append(List_Index)
         mega_list.append(cog_embeds)
+
         return mega_list                                                                    
     async def Asyncio_Publisher(self,ctx, cog_embeds):
         Coroutine_Object = await self.set_embed_pageable(cog_embeds, ctx.author, ctx.channel, 60)

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -1,0 +1,312 @@
+import json
+import logging
+from threading import currentThread
+from urllib import response
+import uuid
+import random
+import aiohttp
+import discord
+import discord.ext.commands as commands
+from discord.ext.commands.errors import UserInputError
+import bot.bot_secrets as bot_secrets
+import bot.extensions as ext
+from bot.consts import Colors
+from bot.messaging.events import Events
+
+
+
+
+
+
+
+
+class TriviaCog(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.session = aiohttp.ClientSession()
+
+    @ext.group(case_insensitive=True, invoke_without_command=True)
+    @ext.long.help(
+    "Use !trivia to return a random assortment of 10 trivia questions. React with emojis to submit your answer choice"    )
+    @ext.short_help(
+    "!trivia use !trivia m for custom arguments"    )
+    async def Trivia(self, ctx, *input:str):
+       async with await self.session.get(url=DEFAULT_URL) as resp:  
+            response = json.loads(await resp.text())
+            correct_answers = self.JsonParser(response)
+            await self.Dict_Publisher(ctx, response)
+
+       return
+    @Trivia.command()
+    @ext.long_help(
+        "Specify arguments you want to return such as question number (max 35), category, difficulty, or question type. Use numbers for quicker specification of category by typing in the number beside the category in !help. Use 0 for unused categories!")
+    @ext.short_help("!trivia m <Question Number> <category/substring/number> <Difficulty/Number> <question type>")
+    @ext.example(
+     "Say you want only bool question types (True/False) and default everything else: !trivia m 10 0 0 2 The only truly required argument is Question Number. You can use 0's for categories you don't want to specify")
+    async def manual(self, ctx, *input:str):
+     if len(input) < 1:
+        raise UserInputError("You need more arguments to use this command")
+     FunctionParameters = []   
+     for x in range(0, 3):
+         if input[x] != None:
+             FunctionParameters.insert(x, self.Matching_Function(x))
+         else:
+             FunctionParameters.insert(x, None)
+             break  # End of input we parsed as much as possible     
+
+         
+       
+     url = self.Url_Builder(FunctionParameters)
+     async with await self.session.get(url=url) as resp:  
+            response = json.loads(await resp.text())
+            correct_answers = await self.JsonParser(response)
+
+
+     return
+    async def Url_Builder(self, functionlist):
+        url = URL_BUILDER
+        for x in range(0,3):
+            if functionlist[x] != None:
+                    match x:
+                        case 0:
+                            url = url+ str(functionlist[x])
+                        case 1:
+                            url = url + "&category="+ str(functionlist[x])
+                        case 2: 
+                            url = url + "&difficulty=" + functionlist[x]
+                        case 3:
+                            url = url + "&type="+functionlist[x]             
+
+        return
+    async def Matching_Function(self, case, *input:str):
+     
+     match case:
+        case 0:
+            if input[0].isnumeric():
+                questionnumber = int(input[0])
+                if 0 < questionnumber <= 50:
+                    return questionnumber    
+
+            else:
+                raise UserInputError("Question Number has to be a number within the range of 1 to 50")
+                     
+            
+        case 1:
+            if input[1].isnumeric():
+                trivianumber = int(input[1])
+                if 0< trivianumber <= 24:
+                    return trivianumber+8
+                elif trivianumber == 0:
+                    return None    
+
+            else:
+                triviacategory = input[1].lower()
+                for x in CATEGORYLIST_LOWER:
+                 if(x.find(triviacategory) != -1):
+                     Returnthis = CATEGORYLIST_LOWER.index(x)+9
+                     return Returnthis
+                 else:
+                     raise UserInputError("Category not found!")     
+        case 2:                         
+            if input[2].isnumeric():
+                EvaluteInt = int(input[2])
+                if 0 < EvaluteInt <= 3:
+                    ReturnString = DIFFICULTY_LOWER[EvaluteInt-1]
+                    return ReturnString
+                elif EvaluteInt==0:
+                    return None    
+        
+            else: 
+                 difficulty = input[2].lower()
+                 for x in DIFFICULTY_LOWER:
+                     if(x.find(difficulty) != -1):
+                         Returnthisint = DIFFICULTY_LOWER.index(x)+9
+                         return Returnthisint
+                     else:
+                         raise UserInputError("Difficulty not found")
+        case 3:
+             if input[3].isnumeric():
+                EvaluteInt = int(input[3])
+                if 0 < EvaluteInt < 3:
+                    finalreturn = QUESTIONTYPE_LOWER[EvaluteInt-1]
+                    return finalreturn
+                elif EvaluteInt == 0:
+                    return None    
+             else:
+                 questiontype = questiontype.lower()
+                 for x in QUESTIONTYPE_LOWER:
+                    if(x.find(questiontype) != -1):
+                     return x 
+                    else:
+                        raise UserInputError("Question type invalid.")    
+     return                      
+    async def List_Help(self):
+        embed_list = []
+        embed_list.append(self.helper_fixer(CATEGORYLIST))
+        embed_list.append(self.helper_fixer(DIFFICULTY))
+        embed_list.append(self.helper_fixer(QUESTIONTYPE))
+        embed = discord.Embed(title= "Help Page:",
+         descripton="Help Page:",
+         color=Colors.ClemsonOrange)
+        embed.addfield(name="Categories:", value=CATEGORYLIST)
+         
+        return
+    async def Json_Parser(dictionary):
+        Correct_Answers= []
+        for x in dictionary['results']:
+            Correct_Answers.append(x['correct_answer'])
+        return Correct_Answers
+
+    async def Dict_Publisher(self, ctx, dictionary, Correct_answers):
+        x=0
+        cog_embeds = []
+        List_Index = []
+        for bob in dictionary['result']:
+
+         Answers_List= []   
+         Answers_List = bob['incorrect_answers']
+         Answers_List.append(bob['correct_answer'])
+         random.shuffle(Answers_List)
+         List_Index.append(Answers_List.index(Correct_answers[bob]))  
+         x+=1   
+         embed = discord.Embed(title= "Your Trivia Question:",
+         descripton="Question #"+x,
+         color=Colors.ClemsonOrange)
+         embed.addfield(name="Question:", value=bob['question'])
+         embed.addfield(name="Category:", value=bob['category'])
+         embed.addfield(name="Pick your Answer choice:", inline=False)
+         a = 65
+         for iterative in Answers_List:
+
+            embed.addfield(name=chr(a)+":", value = iterative, inline=False)
+            a=a+1
+         cog_embeds.append(embed)
+        
+        msgembed = await self.bot.messenger.publish(Events.on_set_pageable_embed,
+                                         pages=cog_embeds,
+                                         author=ctx.author,
+                                         channel=ctx.channel,
+                                         timeout=360
+                                         ) 
+        await msgembed.add_reaction('🇦')
+        await msgembed.add_reaction('🇧')
+        await msgembed.add_reaction('🇨')
+        await msgembed.add_reaction('🇩')
+        current_pagenumber = 1
+        max_pagenumber = len(cog_embeds)
+        while not msgembed.empty:
+            
+         reaction  = await self.client.wait_for("reaction_add", timeout=360, check=check)
+         current_pagenumber = await self.On_Reaction(reaction.emoji, List_Index, msgembed, current_pagenumber, max_pagenumber)
+        return msgembed
+    
+
+    async def On_Reaction(self, ctx, reaction, rightanswer, msgembeds, current_page, max_pagenumber):
+
+            if ANSWER_KEY[rightanswer[current_page]] == reaction:
+                del msgembeds[current_page] # Add something to scoreboard to give indication it was right
+            elif MOVEMENT_ARROWS.find(reaction):      
+                Index_Of = MOVEMENT_ARROWS.index(reaction)
+                match Index_Of:
+                    case 0:
+                        return current_page+1
+                    case 1:
+                        if current_page > 1:
+                            return current_page-1
+                    case 2:
+                        return max_pagenumber
+                    case 3:
+                        return 1            
+                
+            return current_page
+
+    def helper_fixer(formatthis):
+         newlist = []
+         for x in formatthis:
+           newlist[x] = '\n'.append(formatthis[x]) + "     Index Of Element:"+formatthis.index([x])
+         for i in range(0, len(formatthis), CHUNK_SIZE):
+             yield newlist[i:i+CHUNK_SIZE]          
+
+CHUNK_SIZE = 15
+
+ANSWER_KEY=['🇦',
+            '🇧',
+            '🇨',
+            '🇩']
+             
+MOVEMENT_ARROWS=['➡️',
+                '⬅️',
+               '⏭️',
+               '⏮️' ]
+
+CATEGORY_OFFSET = 9
+
+URL_BUILDER = R"https://opentdb.com/api.php?amount="
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+DEFAULT_URL = "https://opentdb.com/api.php?amount=10"
+   
+
+
+DIFFICULTY = ["Easy", 
+              "Medium", 
+              "Hard"]
+
+DIFFICULTY_LOWER = [k.lower() for k in DIFFICULTY]
+
+QUESTIONTYPE = [
+    "multiple", 
+    "bool"
+]
+QUESTIONTYPE_LOWER = [k.lower for k in QUESTIONTYPE]
+CATEGORYLIST = ["General Knowledge", #Including this out of consistency to avoid making the offset 10 for no reason. This will be the default value.
+                 "Books", 
+                 "Film", 
+                 "Music", 
+                 "Musicals & Theatres", 
+                 "Television",
+                 "Video Games",
+                 "Board Games",
+                 "Science & Nature", 
+                 "Computers", 
+                 "Mathematics", 
+                 "Mythology", 
+                 "Sports", 
+                 "Geography", 
+                 "History", 
+                 "Politics", 
+                 "Art",
+                "Celebrities",
+               "Animals", 
+               "Vehicles",
+              "Comics",
+             "Gadgets",
+            "Japanese Anime & Manga",
+           "Cartoon & Animations"]
+CATEGORYLIST_LOWER = [k.lower for k in CATEGORYLIST]
+
+def setup(bot):
+    bot.add_cog(TriviaCog(bot))

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -310,3 +310,4 @@ CATEGORYLIST_LOWER = [k.lower for k in CATEGORYLIST]
 
 def setup(bot):
     bot.add_cog(TriviaCog(bot))
+    

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -49,16 +49,13 @@ class TriviaCog(commands.Cog):
         raise UserInputError("You need more arguments to use this command")
      FunctionParameters = []   
      for x in range(0, 3):
-         if input[x] != None:
-             FunctionParameters.insert(x, self.Matching_Function(x))    
+        FunctionParameters.insert(x, self.Matching_Function(x))    
 
-         
-       
+
      url = self.Url_Builder(FunctionParameters)
      async with await self.session.get(url=url) as resp:  
             response = json.loads(await resp.text())
             correct_answers = await self.JsonParser(response)
-
 
      return
     async def Url_Builder(self, functionlist):
@@ -92,7 +89,7 @@ class TriviaCog(commands.Cog):
         case 1:
             if input[1].isnumeric():
                 trivianumber = int(input[1])
-                if 0< trivianumber <= 24:
+                if 0 < trivianumber <= 24:
                     return trivianumber+8
                 elif trivianumber == 0:
                     return None    
@@ -100,7 +97,7 @@ class TriviaCog(commands.Cog):
             else:
                 triviacategory = input[1].lower()
                 for x in CATEGORYLIST_LOWER:
-                 if(x.find(triviacategory) != -1):
+                 if x.find(triviacategory) != -1:
                      Returnthis = CATEGORYLIST_LOWER.index(x)+9
                      return Returnthis
                  else:

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -552,5 +552,3 @@ class Message:
 
 def setup(bot):
     bot.add_cog(TriviaCog(bot))
-
-    

--- a/ClemBot.Bot/bot/cogs/trivia_cog.py
+++ b/ClemBot.Bot/bot/cogs/trivia_cog.py
@@ -50,10 +50,7 @@ class TriviaCog(commands.Cog):
      FunctionParameters = []   
      for x in range(0, 3):
          if input[x] != None:
-             FunctionParameters.insert(x, self.Matching_Function(x))
-         else:
-             FunctionParameters.insert(x, None)
-             break  # End of input we parsed as much as possible     
+             FunctionParameters.insert(x, self.Matching_Function(x))    
 
          
        

--- a/ClemBot.Bot/bot/services/paginate_service.py
+++ b/ClemBot.Bot/bot/services/paginate_service.py
@@ -126,18 +126,15 @@ class PaginateService(BaseService):
             await msg.add_reaction(reaction)
 
         await self.bot.messenger.publish(Events.on_set_deletable, msg=msg, author=author)
-
         if timeout:
             await asyncio.sleep(timeout)
             try:
-                for reaction in self.reactions:
-                    await msg.clear_reaction(reaction)
-                del self.messages[msg.id]
+                await msg.delete()
             except:
                 pass
             finally:
                 log.info('Message: {msg_id} timed out as pageable', msg_id=msg.id)
-
+            
     @BaseService.Listener(Events.on_reaction_add)
     async def change_page(self, reaction: discord.Reaction, user: t.Union[discord.User, discord.Member]):
 

--- a/ClemBot.Bot/requirements.txt
+++ b/ClemBot.Bot/requirements.txt
@@ -18,10 +18,9 @@ colorama==0.4.3
 contextlib2==0.6.0
 dataclasses-json==0.5.3
 dateutils==0.6.8
-discord.py==1.7.3
+discord.py @ git+https://github.com/Rapptz/discord.py@45d498c1b76deaf3b394d17ccf56112fa691d160
 distlib==0.3.1
 distro==1.4.0
-Django==4.0.4
 entrypoints==0.3
 filelock==3.0.12
 flake8==3.7.9

--- a/ClemBot.Bot/requirements.txt
+++ b/ClemBot.Bot/requirements.txt
@@ -18,7 +18,7 @@ colorama==0.4.3
 contextlib2==0.6.0
 dataclasses-json==0.5.3
 dateutils==0.6.8
-discord.py==2.0.0a3575+g45d498c1
+discord.py==1.7.3
 distlib==0.3.1
 distro==1.4.0
 Django==4.0.4

--- a/ClemBot.Bot/requirements.txt
+++ b/ClemBot.Bot/requirements.txt
@@ -18,9 +18,10 @@ colorama==0.4.3
 contextlib2==0.6.0
 dataclasses-json==0.5.3
 dateutils==0.6.8
-discord.py @ git+https://github.com/Rapptz/discord.py@45d498c1b76deaf3b394d17ccf56112fa691d160
+discord.py==2.0.0a3575+g45d498c1
 distlib==0.3.1
 distro==1.4.0
+Django==4.0.4
 entrypoints==0.3
 filelock==3.0.12
 flake8==3.7.9
@@ -44,7 +45,7 @@ mock==4.0.2
 more-itertools==8.4.0
 msgpack==0.6.2
 multidict==4.7.5
-mypy==0.770
+mypy==0.950
 mypy-extensions==0.4.3
 numpy==1.21.0
 ordered-set==4.0.2
@@ -80,7 +81,8 @@ sqlparse==0.4.2
 stevedore==1.32.0
 stringcase==1.2.0
 toml==0.10.1
-typed-ast==1.4.1
+tomli==2.0.1
+typed-ast==1.5.3
 typing-extensions==3.10.0.0
 typing-inspect==0.7.1
 tzdata==2021.5


### PR DESCRIPTION
- 3.10.4 seems to work. I built from scratch with zero conflicts
- Currently the bot wastes 60 seconds with a coroutine sleeping to delete some emojis. It should at least delete the embed as a sort of automatic "trash-can" service. Paginated embeds aren't useful if you can't use them. Slots/static embeds (like memes or gifs) aren't effected. This will drastically reduce clutter.
- Triviacog... with custom pagination 

- TODO:
- Database similar to Slots (Would appreciate help) 
- Add a score-counter to the page.