### PR TITLE
Add Direct Link to Documentation in Help Cog

### DIFF
--- a/ClemBot.Bot/bot/cogs/assignable_roles_cog.py
+++ b/ClemBot.Bot/bot/cogs/assignable_roles_cog.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing as t
 
 import discord
 import discord.ext.commands as commands
@@ -9,7 +8,6 @@ import bot.extensions as ext
 from bot.clem_bot import ClemBot
 from bot.consts import Claims, Colors
 from bot.messaging.events import Events
-from bot.models.role_models import Role
 from bot.utils.helpers import chunk_sequence
 from bot.utils.logging_utils import get_logger
 
@@ -28,6 +26,7 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Lists all roles that have been marked as assignable in this server")
     @ext.short_help("Defines custom assignable roles")
     @ext.example("roles")
+    @ext.docs(["Roles", "UserAssignableRoles"], "roles")
     async def roles(self, ctx: ext.ClemBotCtx, *, input_role: str | None = None) -> None:
         if input_role is None:
             await self.send_role_list(ctx, "Assignable Roles")
@@ -250,6 +249,7 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Command to add a role as assignable in the current guild")
     @ext.short_help("Marks a role as user assignable")
     @ext.example("roles add @SomeExampleRole")
+    @ext.docs(["Roles", "UserAssignableRoles"], "add")
     async def add(self, ctx: ext.ClemBotCtx, *, role: discord.Role) -> None:
         await self.bot.role_route.set_assignable(role.id, True, raise_on_error=True)
 
@@ -263,6 +263,7 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Command to remove a role as assignable in the current guild")
     @ext.short_help("Removes a role as user assignable")
     @ext.example("roles delete @SomeExampleRole")
+    @ext.docs(["Roles", "UserAssignableRoles"], "remove")
     async def remove(self, ctx: ext.ClemBotCtx, *, role: discord.Role) -> None:
         await self.bot.role_route.set_assignable(role.id, False, raise_on_error=True)
 
@@ -275,6 +276,7 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Command to list all currently auto assigned roles in the guild")
     @ext.short_help("Removes a role as auto assigned")
     @ext.example("roles auto")
+    @ext.docs(["Roles", "AutoAssignableRoles"], "roles-auto")
     async def auto(self, ctx: ext.ClemBotCtx) -> None:
         roles = await self.bot.role_route.get_guilds_auto_assigned_roles(ctx.guild.id)
 
@@ -319,6 +321,7 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Command to add a role as auto assigned in the current guild")
     @ext.short_help("Marks a role as auto assigned")
     @ext.example("roles auto add @SomeExampleRole")
+    @ext.docs(["Roles", "AutoAssignableRoles"], "auto-add")
     async def auto_add(self, ctx: ext.ClemBotCtx, *, role: discord.Role) -> None:
 
         roles = await self.bot.role_route.get_guilds_auto_assigned_roles(ctx.guild.id)
@@ -342,11 +345,12 @@ class AssignableRolesCog(commands.Cog):
     @ext.long_help("Command to remove a role as auto assigned in the current guild")
     @ext.short_help("Removes a role as auto assigned")
     @ext.example("roles auto remove @SomeExampleRole")
+    @ext.docs(["Roles", "AutoAssignableRoles"], "auto-remove")
     async def auto_remove(self, ctx: ext.ClemBotCtx, *, role: discord.Role) -> None:
 
         roles = await self.bot.role_route.get_guilds_auto_assigned_roles(ctx.guild.id)
 
-        if not role.id in [r.id for r in roles]:
+        if role.id not in [r.id for r in roles]:
             embed = discord.Embed(
                 title=f"Error: @{role.name} not set as auto assigned", color=Colors.Error
             )

--- a/ClemBot.Bot/bot/cogs/claims_authorization_cog.py
+++ b/ClemBot.Bot/bot/cogs/claims_authorization_cog.py
@@ -22,6 +22,7 @@ class ClaimsAuthorizationCog(commands.Cog):
     )
     @ext.short_help("Claims authorization setup")
     @ext.example(("claims", "claims @some_role", "claims @some_user"))
+    @ext.docs("Claims", "claims")
     async def claims(
         self, ctx: ext.ClemBotCtx, listing: t.Union[discord.Role, discord.Member]
     ) -> None:
@@ -71,6 +72,7 @@ class ClaimsAuthorizationCog(commands.Cog):
     )
     @ext.short_help("Add claims to a given role")
     @ext.example(("claims add emote_add @some_role", "claims add tag_add @some_other_role"))
+    @ext.docs("Claims", "add")
     async def add(self, ctx: ext.ClemBotCtx, claim_t: ClaimsConverter, role: discord.Role) -> None:
         claim: Claims = t.cast(Claims, claim_t)
 
@@ -97,6 +99,7 @@ class ClaimsAuthorizationCog(commands.Cog):
     @ext.long_help("Removes a claim from a given role. ")
     @ext.short_help("Removes a claim from a given role")
     @ext.example(("claims remove emote_add @some_role", "claims delete tag_add @some_other_role"))
+    @ext.docs("Claims", "remove")
     async def remove(
         self, ctx: ext.ClemBotCtx, claim_t: ClaimsConverter, role: discord.Role
     ) -> None:
@@ -126,6 +129,7 @@ class ClaimsAuthorizationCog(commands.Cog):
     @ext.long_help("Lists the currently available bot claims that can be assigned")
     @ext.short_help("Lists the available bot claims")
     @ext.example("claim list")
+    @ext.docs("Claims", "list")
     async def list(self, ctx: ext.ClemBotCtx) -> None:
         claims_str = self.get_all_claims()
 

--- a/ClemBot.Bot/bot/cogs/command_cog.py
+++ b/ClemBot.Bot/bot/cogs/command_cog.py
@@ -57,7 +57,7 @@ class CommandCog(commands.Cog):
             opp_mode = "enable" if model.guild_disabled else "disable"
             embed.set_footer(
                 text=f"You can {opp_mode} this command globally by typing "
-                f"\"{await self.bot.current_prefix(ctx)}cmd {opp_mode} {cmd.name}\""
+                f'"{await self.bot.current_prefix(ctx)}cmd {opp_mode} {cmd.name}"'
             )
         await ctx.send(embed=embed)
 

--- a/ClemBot.Bot/bot/cogs/command_cog.py
+++ b/ClemBot.Bot/bot/cogs/command_cog.py
@@ -21,6 +21,7 @@ class CommandCog(commands.Cog):
     @ext.long_help("Check if a command is enabled or disabled.")
     @ext.short_help("Check if a command is enabled.")
     @ext.example(["command slots", "command help"])
+    @ext.docs("CommandRestrictions", "command")
     async def command(
         self,
         ctx: ext.ClemBotCtx,
@@ -56,7 +57,7 @@ class CommandCog(commands.Cog):
             opp_mode = "enable" if model.guild_disabled else "disable"
             embed.set_footer(
                 text=f"You can {opp_mode} this command globally by typing "
-                f"`{await self.bot.current_prefix(ctx)}cmd {opp_mode} {cmd.name}`"
+                f"\"{await self.bot.current_prefix(ctx)}cmd {opp_mode} {cmd.name}\""
             )
         await ctx.send(embed=embed)
 
@@ -66,6 +67,7 @@ class CommandCog(commands.Cog):
     @ext.long_help("Enable a command server-wide or in a specific channel.")
     @ext.short_help("Enable a command.")
     @ext.example(["command enable search", "command enable slots #my-channel"])
+    @ext.docs("CommandRestrictions", "enable")
     async def enable(
         self,
         ctx: ext.ClemBotCtx,
@@ -120,6 +122,7 @@ class CommandCog(commands.Cog):
             "command disable info #my-channel true",
         ]
     )
+    @ext.docs("CommandRestrictions", "disable")
     async def disable(
         self,
         ctx: ext.ClemBotCtx,

--- a/ClemBot.Bot/bot/cogs/custom_prefix_cog.py
+++ b/ClemBot.Bot/bot/cogs/custom_prefix_cog.py
@@ -1,5 +1,3 @@
-import typing as t
-
 import discord
 import discord.ext.commands as commands
 
@@ -23,6 +21,7 @@ class CustomPrefixCog(commands.Cog):
     )
     @ext.short_help("Configure a custom command prefix")
     @ext.example(("prefix", "prefix ?", "prefix >>"))
+    @ext.docs("CustomPrefix", "prefix")
     async def prefix(self, ctx: ext.ClemBotCtx, *, prefix: str | None = None) -> None:
         # get_prefix returns two mentions as the first possible prefixes in the tuple,
         # those are global, so we don't care about them
@@ -66,6 +65,7 @@ class CustomPrefixCog(commands.Cog):
     @ext.long_help("resets the bot prefix to the default")
     @ext.short_help("resets a custom prefix")
     @ext.example("prefix reset")
+    @ext.docs("CustomPrefix", "reset")
     async def reset(self, ctx: ext.ClemBotCtx) -> None:
         default_prefix = bot_secrets.secrets.bot_prefix
 

--- a/ClemBot.Bot/bot/cogs/designated_channels_cog.py
+++ b/ClemBot.Bot/bot/cogs/designated_channels_cog.py
@@ -21,6 +21,7 @@ class DesignatedChannelsCog(commands.Cog):
     )
     @ext.short_help("Designated channel configuration")
     @ext.example("channel")
+    @ext.docs("DesignatedChannels", "channel")
     async def channel(self, ctx: ext.ClemBotCtx) -> None:
         """
         Sends a formatted embed of the possible designated channels and their listeners to
@@ -66,6 +67,7 @@ class DesignatedChannelsCog(commands.Cog):
     )
     @ext.short_help("Set a Designated channel")
     @ext.example("channel add user_join_log #some-channel")
+    @ext.docs("DesignatedChannels", "add")
     async def add(
         self, ctx: ext.ClemBotCtx, channel_type: str, channel: discord.TextChannel
     ) -> None:
@@ -110,6 +112,7 @@ class DesignatedChannelsCog(commands.Cog):
     )
     @ext.short_help("Removes a Designated channel listing")
     @ext.example("channel delete user_join_log #some-channel")
+    @ext.docs("DesignatedChannels", "delete")
     async def delete(
         self, ctx: ext.ClemBotCtx, channel_type: str, channel: discord.TextChannel
     ) -> None:

--- a/ClemBot.Bot/bot/cogs/help_cog.py
+++ b/ClemBot.Bot/bot/cogs/help_cog.py
@@ -54,7 +54,9 @@ class HelpCog(commands.Cog):
         assert embed.description is not None  # fuck you mypy...
 
         if command.docs_url():
-            embed.description += f"\nFor further detailed documentation, click [here]({command.docs_url()})."
+            embed.description += (
+                f"\nFor further detailed documentation, click [here]({command.docs_url()})."
+            )
 
         embed.add_field(
             name="Description", value=command.long_help or "No description provided", inline=False
@@ -105,7 +107,9 @@ class HelpCog(commands.Cog):
         )
 
         if command.docs_url():
-            embed.description = f"For further detailed documentation, click [here]({command.docs_url()})."
+            embed.description = (
+                f"For further detailed documentation, click [here]({command.docs_url()})."
+            )
 
         embed.add_field(
             name="Description", value=command.long_help or "No description provided", inline=False

--- a/ClemBot.Bot/bot/cogs/help_cog.py
+++ b/ClemBot.Bot/bot/cogs/help_cog.py
@@ -47,9 +47,15 @@ class HelpCog(commands.Cog):
 
         embed = discord.Embed(
             title=f"```{prefix}{command.qualified_name}```",
-            description=f"for more info on a subcommand run `{prefix}help <SubCommandName>`",
+            description=f"For more info on a sub-command, run `{prefix}help {command.name} <subcommand>`",
             color=Colors.ClemsonOrange,
         )
+
+        assert embed.description is not None  # fuck you mypy...
+
+        if command.docs_url():
+            embed.description += f"\nFor further detailed documentation, click [here]({command.docs_url()})."
+
         embed.add_field(
             name="Description", value=command.long_help or "No description provided", inline=False
         )
@@ -97,6 +103,10 @@ class HelpCog(commands.Cog):
         embed = discord.Embed(
             title=f"```{prefix}{command.qualified_name}```", color=Colors.ClemsonOrange
         )
+
+        if command.docs_url():
+            embed.description = f"For further detailed documentation, click [here]({command.docs_url()})."
+
         embed.add_field(
             name="Description", value=command.long_help or "No description provided", inline=False
         )
@@ -158,7 +168,7 @@ class HelpCog(commands.Cog):
         for command in chunk_sequence(commands_str, HELP_EMBED_SIZE):
             embed = discord.Embed(
                 title=title,
-                description=f"for more info on a command run `{prefix}help <CommandName>`",
+                description=f"For more info on a command run `{prefix}help <CommandName>`",
                 color=Colors.ClemsonOrange,
             )
 
@@ -170,7 +180,7 @@ class HelpCog(commands.Cog):
             embed.add_field(name="Commands", value="\n".join(command))
             embed.add_field(
                 name="Website",
-                value=f"For more information on my commands please visit my website [clembot.io]({bot_secrets.secrets.site_url})",
+                value=f"For more information on my commands, please visit my website [clembot.io]({bot_secrets.secrets.site_url}).",
                 inline=False,
             )
 

--- a/ClemBot.Bot/bot/cogs/moderation_cog/ban_cog.py
+++ b/ClemBot.Bot/bot/cogs/moderation_cog/ban_cog.py
@@ -31,6 +31,7 @@ class BanCog(commands.Cog):
         )
     )
     @ext.required_claims(Claims.moderation_ban)
+    @ext.docs(["Moderation", "Ban"], "ban-1")
     async def ban(
         self,
         ctx: ext.ClemBotCtx,
@@ -120,7 +121,7 @@ class BanCog(commands.Cog):
         if purge_days != 0:
             embed.add_field(
                 name="Messages Purged :no_entry_sign:",
-                value=f'{purge_days} day{"s" if not purge_days == 1 else ""} of messages purged',
+                value=f'{purge_days} day{"s" if purge_days != 1 else ""} of messages purged',
             )
         embed.set_thumbnail(url=subject.display_avatar.url)
 

--- a/ClemBot.Bot/bot/cogs/moderation_cog/infractions_cog.py
+++ b/ClemBot.Bot/bot/cogs/moderation_cog/infractions_cog.py
@@ -1,6 +1,3 @@
-import typing as t
-from datetime import datetime
-
 import discord
 import discord.ext.commands as commands
 
@@ -29,6 +26,7 @@ class InfractionsCog(commands.Cog):
     @ext.short_help("Lists a users infractions")
     @ext.example(("infractions", "infractions @SomeUser"))
     @ext.required_claims(Claims.moderation_infraction_view, Claims.moderation_infraction_view_self)
+    @ext.docs(["Moderation", "Overview"], "infractions")
     async def infractions(self, ctx: ext.ClemBotCtx, user: discord.Member | None = None) -> None:
         user = user or ctx.author
         claims = await self.bot.claim_route.get_claims_user(ctx.author)
@@ -87,6 +85,7 @@ class InfractionsCog(commands.Cog):
     @ext.short_help("Removes an infraction")
     @ext.example(("infractions delete 1", "infractions remove 2"))
     @ext.required_claims(Claims.moderation_warn)
+    @ext.docs(["Moderation", "Overview"], "delete")
     async def delete(self, ctx: ext.ClemBotCtx, infraction_id: int) -> None:
         infraction = await self.bot.moderation_route.get_infraction(infraction_id)
         if not infraction or infraction.guild_id != ctx.guild.id:
@@ -102,7 +101,6 @@ class InfractionsCog(commands.Cog):
         embed.title = f"Infraction {infraction_id} deleted successfully  :white_check_mark:"
         embed.set_author(name=str(ctx.author), icon_url=ctx.author.display_avatar.url)
         await ctx.send(embed=embed)
-        return
 
 
 async def setup(bot: ClemBot) -> None:

--- a/ClemBot.Bot/bot/cogs/moderation_cog/mute_cog.py
+++ b/ClemBot.Bot/bot/cogs/moderation_cog/mute_cog.py
@@ -26,6 +26,7 @@ class MuteCog(commands.Cog):
     @ext.short_help("Mutes a user")
     @ext.example(("mute @SomeUser 1d Timeout", "mute @SomUser 2d1h5m A much longer timeout"))
     @ext.required_claims(Claims.moderation_mute)
+    @ext.docs(["Moderation", "Mute"], "mute-1")
     async def mute(
         self,
         ctx: ext.ClemBotCtx,
@@ -55,9 +56,8 @@ class MuteCog(commands.Cog):
             return
 
         mute_role = discord.utils.get(ctx.guild.roles, name=Moderation.mute_role_name)
-        if not mute_role:
-            if not await self._create_mute_role(ctx):
-                return
+        if not mute_role and not await self._create_mute_role(ctx):
+            return
 
         mutes = await self.bot.moderation_route.get_guild_mutes_user(ctx.guild.id, subject.id)
         if any(i.active for i in mutes):
@@ -134,6 +134,7 @@ class MuteCog(commands.Cog):
     @ext.short_help("Unmutes a user")
     @ext.example("Unmute @SomeUser Timeout")
     @ext.required_claims(Claims.moderation_mute)
+    @ext.docs(["Moderation", "Mute"], "unmute")
     async def unmute(
         self, ctx: ext.ClemBotCtx, subject: discord.Member, *, reason: str | None
     ) -> None:

--- a/ClemBot.Bot/bot/cogs/moderation_cog/warn_cog.py
+++ b/ClemBot.Bot/bot/cogs/moderation_cog/warn_cog.py
@@ -20,6 +20,7 @@ class WarnCog(commands.Cog):
     @ext.example("warn @SomeUser an example warning")
     @ext.required_claims(Claims.moderation_mute)
     @ext.required_claims(Claims.moderation_warn)
+    @ext.docs(["Moderation", "Warning"], "warn-1")
     async def warn(self, ctx: ext.ClemBotCtx, subject: discord.Member, *, reason: str) -> None:
 
         if ctx.author.roles[-1].position <= subject.roles[-1].position:

--- a/ClemBot.Bot/bot/cogs/tags_cog.py
+++ b/ClemBot.Bot/bot/cogs/tags_cog.py
@@ -34,6 +34,7 @@ class TagCog(commands.Cog):
     )
     @ext.short_help("Supports custom tag functionality")
     @ext.example(("tag", "tag mytag"))
+    @ext.docs("Tags", "tag")
     async def tag(self, ctx: ext.ClemBotCtx, tag_name: str | None = None) -> None:
         # check if a tag name was given
         if tag_name:
@@ -85,6 +86,7 @@ class TagCog(commands.Cog):
     )
     @ext.short_help("Lists owned tags")
     @ext.example(["tag owned", "tag owned @user"])
+    @ext.docs("Tags", "owned")
     # returns a list of all tags owned by the calling user or given user returned in pages
     async def owned(self, ctx: ext.ClemBotCtx, user: discord.Member | None = None) -> None:
         if not user:
@@ -127,6 +129,7 @@ class TagCog(commands.Cog):
     )
     @ext.short_help("Creates a tag")
     @ext.example("tag add mytagname mytagcontent")
+    @ext.docs("Tags", "add")
     async def add(self, ctx: ext.ClemBotCtx, name: str, *, content: str) -> None:
         name = name.lower()
 
@@ -160,6 +163,7 @@ class TagCog(commands.Cog):
     )
     @ext.short_help("Deletes a tag")
     @ext.example("tag delete mytagname")
+    @ext.docs("Tags", "remove")
     async def delete(self, ctx: ext.ClemBotCtx, name: str) -> None:
         if not (tag := await self._check_tag_exists(ctx, name, do_suggestions=True)):
             return
@@ -186,6 +190,7 @@ class TagCog(commands.Cog):
     )
     @ext.short_help("Provides info about tag")
     @ext.example("tag info mytagname")
+    @ext.docs("Tags", "info")
     async def info(self, ctx: ext.ClemBotCtx, name: str) -> None:
         if not (tag := await self._check_tag_exists(ctx, name, do_fuzzy=True, do_suggestions=True)):
             return
@@ -210,6 +215,7 @@ class TagCog(commands.Cog):
     @ext.long_help("Searches for a tag in this guild using the inputted query")
     @ext.short_help("Searches for a tag")
     @ext.example("tag search pepepunch")
+    @ext.docs("Tags", "search")
     async def search(self, ctx: ext.ClemBotCtx, query: str) -> None:
         tags = await self.bot.tag_route.search_tags(ctx.guild.id, query)
 
@@ -223,7 +229,7 @@ class TagCog(commands.Cog):
                 [f"**{i+1}.** `{tag.name}`" for i, tag in enumerate(tags)]
             )
         else:
-            embed.description = "No results found... :/"
+            embed.description = "No results found."
 
         msg = await ctx.send(embed=embed)
         await self.bot.messenger.publish(Events.on_set_deletable, msg=msg, author=ctx.author)
@@ -233,6 +239,7 @@ class TagCog(commands.Cog):
     @ext.short_help("Edits a tag")
     @ext.long_help("Edits the content of a tag")
     @ext.example("tag edit mytagname mynewtagcontent")
+    @ext.docs("Tags", "edit")
     async def edit(self, ctx: ext.ClemBotCtx, name: str, *, content: str) -> None:
         if not (tag := await self._check_tag_exists(ctx, name, do_suggestions=True)):
             return
@@ -256,6 +263,7 @@ class TagCog(commands.Cog):
     @ext.short_help("Claims a tag")
     @ext.long_help("Claims a tag with the given name as your own")
     @ext.example("tag claim mytagname")
+    @ext.docs("Tags", "claim")
     async def claim(self, ctx: ext.ClemBotCtx, name: str) -> None:
         if not (tag := await self._check_tag_exists(ctx, name, do_suggestions=True)):
             return
@@ -276,6 +284,7 @@ class TagCog(commands.Cog):
     @ext.short_help("Lists all unclaimed tags")
     @ext.long_help("Gets a list of all unowned tags available to be claimed")
     @ext.example(["tag unclaimed", "tag unowned"])
+    @ext.docs("Tags", "unclaimed")
     async def unclaimed(self, ctx: ext.ClemBotCtx) -> None:
         guild_tags = await self.bot.tag_route.get_guilds_tags(ctx.guild.id)
         unclaimed_tags = []
@@ -313,6 +322,7 @@ class TagCog(commands.Cog):
     @ext.short_help("Gives your tag to someone else.")
     @ext.long_help("Transfers the tag to the given user.")
     @ext.example(["tag transfer tagname @user", "tag give tagname @user"])
+    @ext.docs("Tags", "transfer")
     async def transfer(self, ctx: ext.ClemBotCtx, name: str, user: discord.User) -> None:
         # check if user is a bot
         if user.bot:
@@ -346,6 +356,7 @@ class TagCog(commands.Cog):
     @ext.ignore_claims_pre_invoke()
     @ext.short_help("Configure a custom command tag prefix")
     @ext.example(("tag prefix", "tag prefix ?", "tag prefix >>"))
+    @ext.docs("Tags", "prefix")
     async def prefix(self, ctx: ext.ClemBotCtx, *, tag_prefix: str | None = None) -> None:
         # get_prefix returns two mentions as the first possible prefixes in the tuple,
         # those are global, so we don't care about them
@@ -386,6 +397,7 @@ class TagCog(commands.Cog):
     @ext.long_help("Resets the bot tag prefix to the default")
     @ext.short_help("Resets the custom tag prefix")
     @ext.example("tag prefix reset")
+    @ext.docs("Tags", "tag-reset")
     async def reset(self, ctx: ext.ClemBotCtx) -> None:
         if DEFAULT_TAG_PREFIX in await self.bot.get_tag_prefix(ctx):
             return await self._error_embed(ctx, f"{DEFAULT_TAG_PREFIX} is already the tag prefix.")

--- a/ClemBot.Bot/bot/cogs/welcome_message_cog.py
+++ b/ClemBot.Bot/bot/cogs/welcome_message_cog.py
@@ -20,6 +20,7 @@ class WelcomeMessageCog(commands.Cog):
     )
     @ext.short_help("Set a server welcome dm message")
     @ext.example("welcome")
+    @ext.docs("WelcomeMessage", "welcome")
     async def welcome(self, ctx: ext.ClemBotCtx) -> None:
         message = await self.bot.welcome_message_route.get_welcome_message(ctx.guild.id)
 
@@ -37,6 +38,7 @@ class WelcomeMessageCog(commands.Cog):
     @ext.long_help("Sets a welcome message to be dmd to every new member")
     @ext.short_help("Sets the welcome message")
     @ext.example("welcome set welcome to our amazing server")
+    @ext.docs("WelcomeMessage", "set")
     async def set(self, ctx: ext.ClemBotCtx, *, content: str) -> None:
         await self.bot.welcome_message_route.set_welcome_message(
             ctx.guild.id, content, raise_on_error=True
@@ -52,6 +54,7 @@ class WelcomeMessageCog(commands.Cog):
     @ext.long_help("Allows for server admins to remove a welcome message from their server")
     @ext.short_help("Removes the welcome message")
     @ext.example("welcome delete")
+    @ext.docs("WelcomeMessage", "delete")
     async def delete(self, ctx: ext.ClemBotCtx) -> None:
         message = await self.bot.welcome_message_route.get_welcome_message(ctx.guild.id)
         if not message:

--- a/ClemBot.Bot/bot/extensions.py
+++ b/ClemBot.Bot/bot/extensions.py
@@ -5,6 +5,7 @@ from discord.ext.commands._types import BotT
 from discord.ext.commands.errors import BadArgument
 
 from bot.consts import Claims
+from bot.bot_secrets import secrets
 
 if t.TYPE_CHECKING:
     from bot.clem_bot import ClemBot
@@ -167,6 +168,20 @@ def ban_disabling() -> T_EXTBASE_DECO_WRAP:
     return wrapper
 
 
+def docs(page: str | list[str], header: str | None = None) -> T_EXTBASE_DECO_WRAP:
+    def wrapper(func: T_EXTBASE) -> T_EXTBASE:
+        if isinstance(func, ExtBase):
+            func.page = page if isinstance(page, str) else "/".join(page)
+            func.header = header
+        else:
+            setattr(func, "page", page if isinstance(page, str) else "/".join(page))
+            setattr(func, "header", header)
+
+        return func
+
+    return wrapper
+
+
 class ExtBase:
     def __init__(self, func: t.Any, **kwargs: t.Any) -> None:
         self.chainable_output = kwargs.get("chainable_output", False) or getattr(
@@ -189,6 +204,8 @@ class ExtBase:
         self.allow_disable = t.cast(
             bool, kwargs.get("allow_disable") or getattr(func, "allow_disable", True)
         )
+        self.page: str | None = getattr(func, "page", None)
+        self.header: str | None = getattr(func, "header", None)
 
     def claims_check(self, claims: t.Sequence[str | Claims]) -> bool:
         """
@@ -216,6 +233,20 @@ class ExtBase:
 
         # check for intersection of two sets of claims, if there is one we have a valid user
         return len(set(str_claims).intersection(self.claims)) > 0
+
+    def docs_url(self) -> str | None:
+        """
+        Gets the full URL of the documentation for the command.
+        Uses the `docs_url` string stored in BotSecrets and appends the page and header, if given.
+
+        Returns:
+            The full URL to the documentation of the command or None if `BotSecrets.docs_url` is None or `page` is None.
+        """
+        if not secrets.docs_url or not self.page:
+            return None
+
+        return f"{secrets.docs_url}{'/' if not secrets.docs_url.endswith('/') else ''}" \
+               f"{self.page}{f'#{self.header}' if self.header else ''}"
 
 
 class ClemBotCommand(discord.ext.commands.Command[t.Any, t.Any, t.Any], ExtBase):

--- a/ClemBot.Bot/bot/extensions.py
+++ b/ClemBot.Bot/bot/extensions.py
@@ -4,8 +4,8 @@ import discord
 from discord.ext.commands._types import BotT
 from discord.ext.commands.errors import BadArgument
 
-from bot.consts import Claims
 from bot.bot_secrets import secrets
+from bot.consts import Claims
 
 if t.TYPE_CHECKING:
     from bot.clem_bot import ClemBot
@@ -245,8 +245,10 @@ class ExtBase:
         if not secrets.docs_url or not self.page:
             return None
 
-        return f"{secrets.docs_url}{'/' if not secrets.docs_url.endswith('/') else ''}" \
-               f"{self.page}{f'#{self.header}' if self.header else ''}"
+        return (
+            f"{secrets.docs_url}{'/' if not secrets.docs_url.endswith('/') else ''}"
+            f"{self.page}{f'#{self.header}' if self.header else ''}"
+        )
 
 
 class ClemBotCommand(discord.ext.commands.Command[t.Any, t.Any, t.Any], ExtBase):

--- a/ClemBot.Bot/bot/extensions.py
+++ b/ClemBot.Bot/bot/extensions.py
@@ -1,4 +1,5 @@
 import typing as t
+from urllib.parse import urljoin
 
 import discord
 from discord.ext.commands._types import BotT
@@ -245,10 +246,7 @@ class ExtBase:
         if not secrets.docs_url or not self.page:
             return None
 
-        return (
-            f"{secrets.docs_url}{'/' if not secrets.docs_url.endswith('/') else ''}"
-            f"{self.page}{f'#{self.header}' if self.header else ''}"
-        )
+        return f"{urljoin(secrets.docs_url, self.page)}{f'#{self.header}' if self.header else ''}"
 
 
 class ClemBotCommand(discord.ext.commands.Command[t.Any, t.Any, t.Any], ExtBase):

--- a/ClemBot.Docs/docs/Claims.md
+++ b/ClemBot.Docs/docs/Claims.md
@@ -111,3 +111,23 @@ Removes a claim from a given role, everyone who has that role will no longer hav
 ```
 !claims add tag_add @MyCoolRole
 ```
+
+### List
+
+Lists the currently available bot claims that can be assigned.
+
+#### Aliases
+
+- `get`
+
+#### Format
+
+```
+!claim list
+```
+
+#### Example
+
+```
+!claims get
+```

--- a/ClemBot.Docs/docs/CustomPrefix.md
+++ b/ClemBot.Docs/docs/CustomPrefix.md
@@ -5,12 +5,15 @@ sidebar_position: 2
 # Custom Prefix
 
 ## Overview
+
 A command prefix is the character or phrase that notifies ClemBot that you wish to invoke a command.
 
 ### Command Example
+
 ```txt title="Discord Message"
 !about
 ```
+
 `!` is the command prefix and `about` is the name of the command that you wish to invoke.
 
 :::tip
@@ -21,7 +24,8 @@ Use `@ClemBot prefix` to find what prefix the bot has been set to in your server
 :::
 
 ## Dashboard
-Changes a server's prefix to a given value. 
+
+Changes a server's prefix to a given value.
 If no value is provided, the current in-use prefix is shown.
 
 ## Commands
@@ -29,12 +33,17 @@ If no value is provided, the current in-use prefix is shown.
 ### Prefix
 
 #### Aliases
+
 * `prefixs`
 
 #### Required [Claims](./Claims.md)
-* `custom_prefix_set`
+
+```
+custom_prefix_set
+```
 
 #### Format
+
 ```txt title="View the current prefix"
 !prefix 
 ```
@@ -42,11 +51,43 @@ If no value is provided, the current in-use prefix is shown.
 ```txt title="Change the current prefix"
 !prefix <NewPrefix>
 ```
+
 #### Example
+
 ```
 !prefix
 ```
 
 ```
 !prefix ?
+```
+
+### Reset
+
+Resets the bot prefix to the default, `!`.
+
+#### Aliases
+
+- `revert`
+
+#### Required [Claims](./Claims.md)
+
+```
+custom_prefix_set
+```
+
+#### Format
+
+```
+!prefix reset
+```
+
+#### Example
+
+```
+!prefix reset
+```
+
+```
+!prefix revert
 ```

--- a/ClemBot.Docs/docs/Moderation/Mute.md
+++ b/ClemBot.Docs/docs/Moderation/Mute.md
@@ -1,28 +1,36 @@
 ---
 sidebar_position: 4
 ---
+
 # Mute
 
 ## Overview
+
 Mutes silence an individual and prevent them from sending messages or joining voice channels for a given amount of time.
 
 ## Setup
-Mutes require a one time initial setup for ClemBot to create the mute role and add it to all the channels. 
-This might take a while depending on how many channels your server has. 
-To avoid a heavy startup load the bot will prompt you to initialize the role when you run the mute command for the first time. 
+
+Mutes require a one time initial setup for ClemBot to create the mute role and add it to all the channels.
+This might take a while depending on how many channels your server has.
+To avoid a heavy startup load the bot will prompt you to initialize the role when you run the mute command for the first
+time.
 After the initial setup is complete it will then apply the mute as normal.
 
 :::caution
-If you have a large server with many channels this initial setup can take a minute or two due to discord rate limits, do not worry though. 
+If you have a large server with many channels this initial setup can take a minute or two due to discord rate limits, do
+not worry though.
 Once the mute role is set up, the bot will mute the user as requested.
 :::
 
 ## Duration String
-ClemBot supports time strings to specify how long a mute should last. 
-For example, to mute someone for 12 hours you would use the string `12h`. 
-To mute someone for twelve days and thirty minutes you would use the string `12d30m`...and so on in any combination you desire.
+
+ClemBot supports time strings to specify how long a mute should last.
+For example, to mute someone for 12 hours you would use the string `12h`.
+To mute someone for twelve days and thirty minutes you would use the string `12d30m`...and so on in any combination you
+desire.
 
 **`Available Options`**
+
 ```
 - years: `Y`, `y`, `year`, `years`
 - months: `M`, `month`, `months`
@@ -41,15 +49,50 @@ The string needs to be in descending order, i.e., `1y4m1w2d5h2m30s`.
 
 ### Mute
 
-#### Required [Claims](./Claims.md)
-* `moderation_mute`
+#### Required [Claims](./../Claims.md)
+
+```
+moderation_mute
+```
 
 #### Format
+
 ```
-!mute @User <Duration> <Reason>
+!mute @User <duration> [reason]
 ```
 
 #### Example
+
 ```
 !mute @User 1d1h Spamming and trolling
+```
+
+### Unmute
+
+Remove an active mute from a user, with an optional reason.
+
+:::note
+Un-muting a user does not remove the [infraction](./Overview.md#infractions) from them.
+:::
+
+#### Required [Claims](./../Claims.md)
+
+```
+moderation_mute
+```
+
+#### Format
+
+```
+!unmute @user [reason]
+```
+
+#### Example
+
+```
+!unmute @myfriend
+```
+
+```
+!unmute @smatep Are you going to admit that C# is better than Java now?
 ```

--- a/ClemBot.Docs/docs/Tags.md
+++ b/ClemBot.Docs/docs/Tags.md
@@ -5,26 +5,32 @@ sidebar_position: 8
 # Tags
 
 ## Overview
-Tags are custom commands that allow for users to create custom responses to a given tag name. 
-Simply add a tag, and then invoke it with either command notation or inline notation and ClemBot will respond with that tags content in a given channel.
 
-ClemBot's tags support the idea of ownership. 
-If a user creates a tag, that tag is owned by them until they either leave the server or transfer the tag to someone else. 
-By owning the tag they are allowed to either edit or delete the tag. 
-When a user leaves a server all their owned tags become unclaimed and are free to be claimed by anyone else in the server.
+Tags are custom commands that allow for users to create custom responses to a given tag name.
+Simply add a tag, and then invoke it with either command notation or inline notation and ClemBot will respond with that
+tags content in a given channel.
 
-ClemBot also tracks what tags are popular and allows for you to access that information. 
-You can view the total number of uses of a tag as well as its owner and creation date with the tag info command or on the dashboard.
+ClemBot's tags support the idea of ownership.
+If a user creates a tag, that tag is owned by them until they either leave the server or transfer the tag to someone
+else.
+By owning the tag they are allowed to either edit or delete the tag.
+When a user leaves a server all their owned tags become unclaimed and are free to be claimed by anyone else in the
+server.
+
+ClemBot also tracks what tags are popular and allows for you to access that information.
+You can view the total number of uses of a tag as well as its owner and creation date with the tag info command or on
+the dashboard.
 
 :::caution
 If you leave the server, all your tags will become unowned and be up for grabs for anyone else in the server.
 :::
 
 ### Inline Notation
-Tags in ClemBot can be invoked in the middle of a message by prefixing the tag name with a `$`. 
+
+Tags in ClemBot can be invoked in the middle of a message by prefixing the tag name with a `$`.
 This allows for more organic tag usage in the middle of a conversation.
 
-:::note 
+:::note
 By default, the tag prefix for any server is `$`. However, this can be changed.
 See [Prefix](./Tags.md#prefix) on how to view, change, and reset the prefix.
 :::
@@ -36,19 +42,23 @@ Hello there new person. Have you checked out $funstufftodo here yet?
 ```
 
 ## Dashboard
-A guilds tags can be viewed from the tag tab on the dashboard. 
+
+A guilds tags can be viewed from the tag tab on the dashboard.
 You can filter tags, create new tags or just view what tags have been created.
 
 ## Commands
 
 ### Tag
-If invoked with no tag name it will show all tags in the server. 
+
+If invoked with no tag name it will show all tags in the server.
 If a name is provided, it will attempt to invoke that tag.
 
 #### Aliases
+
 * `tags`
 
 #### Format
+
 ```txt title="List all tags in the server"
 !tag
 ```
@@ -56,6 +66,7 @@ If a name is provided, it will attempt to invoke that tag.
 ```txt title="Invoke a given tag"
 !tag <tagname>
 ```
+
 #### Example
 
 ```
@@ -67,13 +78,16 @@ If a name is provided, it will attempt to invoke that tag.
 ```
 
 ### Add
+
 Create a tag in the server.
 
 #### Aliases
+
 * `create`
 * `make`
 
 #### Required [Claims](./Claims.md)
+
 * `tag_add`
 
 #### Format
@@ -81,6 +95,7 @@ Create a tag in the server.
 ```
 !tag add <TagName> <TagContent>
 ```
+
 #### Example
 
 ```
@@ -88,13 +103,16 @@ Create a tag in the server.
 ```
 
 ### Remove
+
 Delete a tag from the server.
 
 #### Aliases
+
 * `delete`
 * `remove`
 
 #### Required [Claims](./Claims.md)
+
 * `tag_delete`
 
 :::note
@@ -106,6 +124,7 @@ You do not need the `tag_delete` claim to delete a tag that you own.
 ```
 !tag delete <TagName>
 ```
+
 #### Example
 
 ```
@@ -113,6 +132,7 @@ You do not need the `tag_delete` claim to delete a tag that you own.
 ```
 
 ### Edit
+
 Edit a tag in the server.
 
 #### Format
@@ -120,34 +140,91 @@ Edit a tag in the server.
 ```
 !tag edit <TagName> <NewTagContent>
 ```
+
 #### Example
 
 ```
 !tag edit MyTag ClemBot is an super super super awesome bot!
 ```
+
 ### Info
+
 Gets info about a given tag in a server.
 
 #### Aliases
+
 * `about`
 
 #### Format
+
 ```
 !tag info <TagName>
 ```
+
 #### Example
 
 ```
 !tag info MyTag
 ```
 
+### Search
+
+Searches for a tag in the guild/server using the query provided.
+
+#### Aliases
+
+- `find`
+
+#### Format
+
+```
+!tag search <query>
+```
+
+#### Example
+
+```
+!tag find my_tag
+```
+
+```
+!tag search thingsyoucandohere
+```
+
+### Owned
+
+Lists all tags owned by you or a given user, if provided.
+
+#### Aliases
+
+- `claimed`
+
+#### Format
+
+```
+!tag owned [user]
+```
+
+#### Example
+
+```
+!tag owned
+```
+
+```
+!tag claimed @myfriend
+```
+
 ### Claim
+
 Claims a given unowned tag.
 
 #### Format
+
 ```
 !tag claim <TagName>
 ```
+
 #### Example
 
 ```
@@ -155,12 +232,15 @@ Claims a given unowned tag.
 ```
 
 ### Transfer
+
 Transfers a given owned tag to a new owner in the same server.
 
 #### Format
+
 ```
 !tag transfer <TagName> <TagRecipient>
 ```
+
 #### Example
 
 ```
@@ -172,6 +252,7 @@ If a user has the `tag_transfer` [claim](./Claims.md), they can transfer tags th
 :::
 
 ### Unclaimed
+
 Lists all unclaimed tags in the server.
 
 #### Example
@@ -203,6 +284,7 @@ Gets the current tag prefix.
 ```txt title="Set a custom tag prefix"
 !tag prefix #
 ```
+
 :::note
 Custom tag prefixes can have more than one character.
 :::
@@ -211,6 +293,7 @@ Custom tag prefixes cannot contain the character <code>`</code>.
 :::
 
 ##### Required [Claims](./Claims)
+
 - `custom_tag_prefix_set`
 
 :::note
@@ -222,6 +305,7 @@ The command `!tag prefix` does not require the claim, but `!tag prefix <new pref
 Resets the tag prefix.
 
 ##### Aliases
+
 - `revert`
 
 ##### Example
@@ -231,6 +315,7 @@ Resets the tag prefix.
 ```
 
 ##### Required [Claims](./Claims)
+
 - `custom_tag_prefix_set`
 
 :::note


### PR DESCRIPTION
This PR adds something incredibly simple, but something that's been needed for a long time: direct links to documentation.

When developing a new cog or group of commands, after documentation is complete, the developer can simply annotate the cog similarly to the following examples:
```py
@ext.docs("Page", "header")
def foo(self, ctx: ext.ClemBotCtx) -> None:
    ...
```
```py
@ext.docs(["ParentPage", "ChildPage"], "my-header")
def foo(self, ctx: ext.ClemBotCtx) -> None:
    ...
```
```py
@ext.docs("PageOnly")
def foo(self, ctx: ext.ClemBotCtx) -> None:
    ...
```

The URL is generated like so:
```
<bot secrets docs_url>/<pages split by '/'>#<header>
```
<sub>* `/` is only added if not present at the end of `docs_url`.</sub>
<sub>* `#<header>` is only added if not `None`.</sub>

If this annotation is present, ClemBot will add the link to the description in the `!help` command.

![image](https://github.com/ClemBotProject/ClemBot/assets/16947464/d1656946-43c4-4f9b-9003-147763a0cc9b)
