### PR TITLE
Fix Emote Boards

### DIFF
--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Create.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Create.cs
@@ -118,9 +118,10 @@ public class Create
                 ChannelId = request.ChannelId,
                 MessageId = request.MessageId,
                 UserId = request.UserId,
-                Reactions = request.Reactions,
+                Reactions = request.Reactions.Select(id => new EmoteBoardPostReaction { UserId = id }).ToList(),
                 Messages = messages
             });
+
             await _context.SaveChangesAsync();
 
             await _mediator.Send(new ClearEmoteBoardPostRequest

--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Details.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Details.cs
@@ -90,14 +90,19 @@ public class Details
 
             foreach (var post in posts)
             {
-                var channelMessageIds = _context.EmoteBoardMessages
+                var channelMessageIds = await _context.EmoteBoardMessages
                     .Where(m => m.EmoteBoardPostId == post.Id)
                     .Select(m => new
                     {
                         m.ChannelId,
                         m.MessageId
                     })
-                    .ToDictionary(kvp => kvp.ChannelId, kvp => kvp.MessageId);
+                    .ToDictionaryAsync(kvp => kvp.ChannelId, kvp => kvp.MessageId);
+
+                var reactions = await _context.EmoteBoardPostReactions
+                    .Where(rp => rp.EmoteBoardPostId == post.Id)
+                    .Select(rp => rp.UserId)
+                    .ToListAsync();
 
                 dtos.Add(new EmoteBoardPostDto
                 {
@@ -105,7 +110,7 @@ public class Details
                     ChannelId = post.ChannelId,
                     MessageId = post.MessageId,
                     UserId = post.UserId,
-                    Reactions = post.Reactions,
+                    Reactions = reactions,
                     ChannelMessageIds = channelMessageIds
                 });
             }

--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Popular.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Popular.cs
@@ -83,7 +83,8 @@ public class Popular
 
             var posts = await _context.EmoteBoardPosts
                 .Where(p => board != null ? p.EmoteBoardId == board.Id : p.EmoteBoard.GuildId == request.GuildId)
-                .OrderBy(p => p.Reactions.Count)
+                .Include(p => p.Reactions)
+                .OrderByDescending(p => p.Reactions.Count)
                 .Take(request.Limit)
                 .Select(p => new LeaderboardSlot
                 {

--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Posts.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Posts.cs
@@ -78,7 +78,7 @@ public class Posts
             var posts = await _context.EmoteBoardPosts
                 .Where(p => board != null ? p.EmoteBoardId == board.Id : p.EmoteBoard.GuildId == request.GuildId)
                 .GroupBy(p => p.UserId)
-                .OrderBy(group => group.Count())
+                .OrderByDescending(group => group.Count())
                 .Take(request.Limit)
                 .Select(g => new LeaderboardSlot
                 {

--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Reactions.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Reactions.cs
@@ -77,13 +77,14 @@ public class Reactions
 
             var posts = await _context.EmoteBoardPosts
                 .Where(p => board != null ? p.EmoteBoardId == board.Id : p.EmoteBoard.GuildId == request.GuildId)
+                .Include(p => p.Reactions)
                 .GroupBy(p => p.UserId)
                 .Select(group => new LeaderboardSlot
                 {
                     UserId = group.Key,
                     ReactionCount = group.Select(p => p.Reactions).Count()
                 })
-                .OrderBy(slot => slot.ReactionCount)
+                .OrderByDescending(slot => slot.ReactionCount)
                 .Take(request.Limit)
                 .ToListAsync();
 

--- a/ClemBot.Api/ClemBot.Api.Data/Contexts/ClemBotContext.cs
+++ b/ClemBot.Api/ClemBot.Api.Data/Contexts/ClemBotContext.cs
@@ -31,6 +31,7 @@ public class ClemBotContext : DbContext
     public DbSet<EmoteBoard> EmoteBoards { get; set; } = null!;
     public DbSet<EmoteBoardMessage> EmoteBoardMessages { get; set; } = null!;
     public DbSet<EmoteBoardPost> EmoteBoardPosts { get; set; } = null!;
+    public DbSet<EmoteBoardPostReaction> EmoteBoardPostReactions { get; set; } = null!;
     public DbSet<Guild> Guilds { get; set; } = null!;
     public DbSet<GuildSetting> GuildSettings { get; set; } = null!;
     public DbSet<GuildUser> GuildUser { get; set; } = null!;

--- a/ClemBot.Api/ClemBot.Api.Data/Migrations/20231021011235_AddEmoteBoardPostReaction.Designer.cs
+++ b/ClemBot.Api/ClemBot.Api.Data/Migrations/20231021011235_AddEmoteBoardPostReaction.Designer.cs
@@ -4,6 +4,7 @@ using ClemBot.Api.Common.Enums;
 using ClemBot.Api.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ClemBot.Api.Data.Migrations
 {
     [DbContext(typeof(ClemBotContext))]
-    partial class ClemBotContextModelSnapshot : ModelSnapshot
+    [Migration("20231021011235_AddEmoteBoardPostReaction")]
+    partial class AddEmoteBoardPostReaction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ClemBot.Api/ClemBot.Api.Data/Migrations/20231021011235_AddEmoteBoardPostReaction.cs
+++ b/ClemBot.Api/ClemBot.Api.Data/Migrations/20231021011235_AddEmoteBoardPostReaction.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ClemBot.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmoteBoardPostReaction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Reactions",
+                table: "EmoteBoardPosts");
+
+            migrationBuilder.CreateTable(
+                name: "EmoteBoardPostReactions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EmoteBoardPostId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<decimal>(type: "numeric(20,0)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmoteBoardPostReactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EmoteBoardPostReactions_EmoteBoardPosts_EmoteBoardPostId",
+                        column: x => x.EmoteBoardPostId,
+                        principalTable: "EmoteBoardPosts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmoteBoardPostReactions_EmoteBoardPostId",
+                table: "EmoteBoardPostReactions",
+                column: "EmoteBoardPostId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmoteBoardPostReactions");
+
+            migrationBuilder.AddColumn<decimal[]>(
+                name: "Reactions",
+                table: "EmoteBoardPosts",
+                type: "numeric(20,0)[]",
+                nullable: false,
+                defaultValue: new decimal[0]);
+        }
+    }
+}

--- a/ClemBot.Api/ClemBot.Api.Data/Models/EmoteBoardPost.cs
+++ b/ClemBot.Api/ClemBot.Api.Data/Models/EmoteBoardPost.cs
@@ -20,7 +20,7 @@ public class EmoteBoardPost
     public int EmoteBoardId { get; set; }
     public EmoteBoard EmoteBoard { get; set; } = null!;
 
-    public List<ulong> Reactions { get; set; } = null!;
+    public List<EmoteBoardPostReaction> Reactions { get; set; } = new();
 
     public List<EmoteBoardMessage> Messages { get; set; } = null!;
 }

--- a/ClemBot.Api/ClemBot.Api.Data/Models/EmoteBoardPostReaction.cs
+++ b/ClemBot.Api/ClemBot.Api.Data/Models/EmoteBoardPostReaction.cs
@@ -1,0 +1,11 @@
+﻿namespace ClemBot.Api.Data.Models;
+
+public class EmoteBoardPostReaction
+{
+    public int Id { get; set; }
+
+    public int EmoteBoardPostId { get; set; }
+    public EmoteBoardPost EmoteBoardPost { get; set; } = null!;
+
+    public ulong UserId { get; set; }
+}

--- a/ClemBot.Bot/bot/cogs/emote_board_cog.py
+++ b/ClemBot.Bot/bot/cogs/emote_board_cog.py
@@ -169,7 +169,7 @@ class EmoteBoardCog(commands.Cog):
             name="Number of Posts", value="\n".join(posts) if posts else "None", inline=False
         )
         embed.add_field(
-            name="Number of Reactions",
+            name="Reactions Received",
             value="\n".join(reactions) if reactions else "None",
             inline=False,
         )

--- a/ClemBot.Bot/bot/models/emote_board_models.py
+++ b/ClemBot.Bot/bot/models/emote_board_models.py
@@ -56,8 +56,10 @@ class PostLeaderboardSlot(ClemBotModel):
     post_count: int
 
     def format(self, index: int, board_name: str | None = None) -> str:
-        return (f"{index + 1}. **<@{self.user_id}> {self.post_count}{f' {board_name}' if board_name else ''} post"
-                f"{'s' if self.post_count > 1 else ''}**")
+        return (
+            f"{index + 1}. **<@{self.user_id}> {self.post_count}{f' {board_name}' if board_name else ''} post"
+            f"{'s' if self.post_count > 1 else ''}**"
+        )
 
 
 class ReactionLeaderboardSlot(ClemBotModel):
@@ -67,5 +69,7 @@ class ReactionLeaderboardSlot(ClemBotModel):
     def format(self, index: int, emote: str | discord.Emoji | None = None) -> str:
         if isinstance(emote, discord.Emoji):
             emote = str(emote)
-        return (f"{index + 1}. **<@{self.user_id}> {self.reaction_count}{f' {emote}' if emote else ''} reaction"
-                f"{'s' if self.reaction_count > 1 else ''}**")
+        return (
+            f"{index + 1}. **<@{self.user_id}> {self.reaction_count}{f' {emote}' if emote else ''} reaction"
+            f"{'s' if self.reaction_count > 1 else ''}**"
+        )

--- a/ClemBot.Bot/bot/models/emote_board_models.py
+++ b/ClemBot.Bot/bot/models/emote_board_models.py
@@ -30,7 +30,7 @@ class EmoteBoardPost(ClemBotModel):
 
 class EmoteBoardReaction(ClemBotModel):
     update: bool
-    reactions: int | None
+    reaction_count: int | None
 
 
 class PopularLeaderboardSlot(ClemBotModel):
@@ -56,7 +56,8 @@ class PostLeaderboardSlot(ClemBotModel):
     post_count: int
 
     def format(self, index: int, board_name: str | None = None) -> str:
-        return f"{index + 1}. **<@{self.user_id}> {self.post_count}{f' {board_name}' if board_name else ''} posts**"
+        return (f"{index + 1}. **<@{self.user_id}> {self.post_count}{f' {board_name}' if board_name else ''} post"
+                f"{'s' if self.post_count > 1 else ''}**")
 
 
 class ReactionLeaderboardSlot(ClemBotModel):
@@ -66,4 +67,5 @@ class ReactionLeaderboardSlot(ClemBotModel):
     def format(self, index: int, emote: str | discord.Emoji | None = None) -> str:
         if isinstance(emote, discord.Emoji):
             emote = str(emote)
-        return f"{index + 1}. **<@{self.user_id}> {self.reaction_count}{f' {emote}' if emote else ''} reactions**"
+        return (f"{index + 1}. **<@{self.user_id}> {self.reaction_count}{f' {emote}' if emote else ''} reaction"
+                f"{'s' if self.reaction_count > 1 else ''}**")

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -136,7 +136,7 @@ class EmoteBoardService(BaseService):
                     assert isinstance(channel, discord.abc.Messageable)
                     embed_msg = await channel.fetch_message(message_id)
                     embed = await self._as_embed(
-                        message, board.reaction_threshold, len(post.reaction_count), board.emote
+                        message, board.reaction_threshold, len(post.reactions), board.emote
                     )
                     await embed_msg.edit(embed=embed)
                 except NotFound:  # Skips over the item if fetch_message() raises `NotFound`
@@ -276,7 +276,7 @@ class EmoteBoardService(BaseService):
             description=f"_Posted in {message.channel.mention} by_ {message.author.mention}",
         )
 
-        embed.add_field(name='Original Message', value=message.jump_url)
+        embed.add_field(name="Original Message", value=message.jump_url)
 
         if message.content:
             for i, chunk in enumerate(self._chunk_string(message.content)):

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -109,6 +109,12 @@ class EmoteBoardService(BaseService):
         try:
             message = await channel.fetch_message(event.message_id)
         except discord.Forbidden:
+            log.info(
+                "Fetching message {message_id} from channel {channel_id} in guild {guild_id} raised Forbidden on_message_edit",
+                message_id=event.message_id,
+                channel_id=event.channel_id,
+                guild_id=event.guild_id
+            )
             return
 
         posts = await self.bot.emote_board_route.get_posts(event.guild_id, event.message_id)

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -113,7 +113,7 @@ class EmoteBoardService(BaseService):
                 "Fetching message {message_id} from channel {channel_id} in guild {guild_id} raised Forbidden on_message_edit",
                 message_id=event.message_id,
                 channel_id=event.channel_id,
-                guild_id=event.guild_id
+                guild_id=event.guild_id,
             )
             return
 

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -57,7 +57,7 @@ class EmoteBoardService(BaseService):
         guild = self.bot.get_guild(event.guild_id)
         assert guild is not None
 
-        channel = guild.get_channel(event.channel_id)
+        channel = guild.get_channel_or_thread(event.channel_id)
         assert channel is not None and isinstance(channel, discord.abc.Messageable)
 
         message = await channel.fetch_message(event.message_id)
@@ -101,10 +101,15 @@ class EmoteBoardService(BaseService):
         guild = self.bot.get_guild(event.guild_id)
         assert guild is not None
 
-        channel = guild.get_channel(event.channel_id)
+        channel = guild.get_channel_or_thread(event.channel_id)
         assert channel is not None and isinstance(channel, discord.abc.Messageable)
 
-        message = await channel.fetch_message(event.message_id)
+        # Attempt to fetch the message, ignore if we do not have permissions.
+        message: discord.Message
+        try:
+            message = await channel.fetch_message(event.message_id)
+        except discord.Forbidden:
+            return
 
         posts = await self.bot.emote_board_route.get_posts(event.guild_id, event.message_id)
 
@@ -125,13 +130,13 @@ class EmoteBoardService(BaseService):
         for post, board in post_boards.items():
             for channel_id, message_id in post.channel_message_ids.items():
                 try:
-                    if not (channel := guild.get_channel(channel_id)):
+                    if not (channel := guild.get_channel_or_thread(channel_id)):
                         continue
 
                     assert isinstance(channel, discord.abc.Messageable)
                     embed_msg = await channel.fetch_message(message_id)
                     embed = await self._as_embed(
-                        message, board.reaction_threshold, len(post.reactions), board.emote
+                        message, board.reaction_threshold, len(post.reaction_count), board.emote
                     )
                     await embed_msg.edit(embed=embed)
                 except NotFound:  # Skips over the item if fetch_message() raises `NotFound`
@@ -150,7 +155,7 @@ class EmoteBoardService(BaseService):
         for post in posts:
             for channel_id, message_id in post.channel_message_ids.items():
                 try:
-                    if not (channel := guild.get_channel(channel_id)):
+                    if not (channel := guild.get_channel_or_thread(channel_id)):
                         continue
 
                     assert isinstance(channel, discord.abc.Messageable)
@@ -187,7 +192,7 @@ class EmoteBoardService(BaseService):
         )
 
         for channel_id in board.channels:
-            if not (channel := guild.get_channel(channel_id)):
+            if not (channel := guild.get_channel_or_thread(channel_id)):
                 continue
             assert isinstance(channel, discord.abc.Messageable)
             message = await channel.send(embed=embed)
@@ -212,16 +217,16 @@ class EmoteBoardService(BaseService):
 
         reaction_dto = await self.bot.emote_board_route.post_reactions(guild, board, message, users)
 
-        if not reaction_dto.update or reaction_dto.reactions is None:
+        if not reaction_dto.update or reaction_dto.reaction_count is None:
             return
 
         embed = await self._as_embed(
-            message, board.reaction_threshold, reaction_dto.reactions, board.emote
+            message, board.reaction_threshold, reaction_dto.reaction_count, board.emote
         )
 
         for channel_id, message_id in post.channel_message_ids.items():
             try:
-                if not (channel := guild.get_channel(channel_id)):
+                if not (channel := guild.get_channel_or_thread(channel_id)):
                     continue
 
                 if not isinstance(channel, discord.abc.Messageable):
@@ -229,7 +234,7 @@ class EmoteBoardService(BaseService):
 
                 embed_msg = await channel.fetch_message(message_id)
                 await embed_msg.edit(embed=embed)
-            except NotFound:
+            except discord.NotFound:
                 continue
 
     async def _get_board_from_emote(
@@ -268,8 +273,10 @@ class EmoteBoardService(BaseService):
         embed = discord.Embed(
             title=title,
             color=Colors.ClemsonOrange,
-            description=f"_Posted in {message.channel.mention} by_ {message.author.mention} [Link]({message.jump_url})",
+            description=f"_Posted in {message.channel.mention} by_ {message.author.mention}",
         )
+
+        embed.add_field(name='Original Message', value=message.jump_url)
 
         if message.content:
             for i, chunk in enumerate(self._chunk_string(message.content)):
@@ -277,7 +284,9 @@ class EmoteBoardService(BaseService):
 
         if message.attachments:
             for attachment in message.attachments:
-                if attachment.content_type == "image":
+                if not attachment.content_type:
+                    continue
+                if attachment.content_type.startswith("image"):
                     embed.set_image(url=attachment.url)
                     break
 


### PR DESCRIPTION
This PR attempts to fix the following issues:
- Messages that we do not have permissions to see will throw a 403 Forbidden, even if we can see it being edited.
- Threads causing an assertion error.
- Images aren't embedding properly.
- Posts aren't being updated with the new emote count.
- Link to original message on post is hard to click on mobile.
- Leaderboard entries are ascending rather than descending.