### PR TITLE
Multiple emoteboard bug fixes

### DIFF
--- a/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Reactions.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/EmoteBoardPosts/Bot/Leaderboard/Reactions.cs
@@ -75,20 +75,20 @@ public class Reactions
                 }
             }
 
-            var posts = await _context.EmoteBoardPosts
+            var reactions = await _context.EmoteBoardPosts
                 .Where(p => board != null ? p.EmoteBoardId == board.Id : p.EmoteBoard.GuildId == request.GuildId)
                 .Include(p => p.Reactions)
                 .GroupBy(p => p.UserId)
                 .Select(group => new LeaderboardSlot
                 {
                     UserId = group.Key,
-                    ReactionCount = group.Select(p => p.Reactions).Count()
+                    ReactionCount = group.Select(p => p.Reactions.Count).Sum()
                 })
                 .OrderByDescending(slot => slot.ReactionCount)
                 .Take(request.Limit)
                 .ToListAsync();
 
-            return QueryResult<List<LeaderboardSlot>>.Success(posts);
+            return QueryResult<List<LeaderboardSlot>>.Success(reactions);
         }
     }
 }

--- a/ClemBot.Bot/bot/clem_bot.py
+++ b/ClemBot.Bot/bot/clem_bot.py
@@ -258,10 +258,14 @@ class ClemBot(commands.Bot):
         await self.publish_with_error(Events.on_raw_message_edit, payload)
 
     async def on_message_delete(self, message: discord.Message) -> None:
+        if not message.guild:
+            return
         if message.author.id != self.user.id:
             await self.publish_with_error(Events.on_message_delete, message)
 
     async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
+        if not payload.guild_id:
+            return
         await self.publish_with_error(Events.on_raw_message_delete, payload)
 
     async def on_after_command_invoke(self, ctx: ext.ClemBotContext["ClemBot"]) -> None:

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -142,7 +142,10 @@ class EmoteBoardService(BaseService):
                     assert isinstance(channel, discord.abc.Messageable)
                     embed_msg = await channel.fetch_message(message_id)
                     embed = await self._as_embed(
-                        message, emote_board.reaction_threshold, len(post.reactions), emote_board.emote
+                        message,
+                        emote_board.reaction_threshold,
+                        len(post.reactions),
+                        emote_board.emote,
                     )
                     await embed_msg.edit(embed=embed)
                 except NotFound:  # Skips over the item if fetch_message() raises `NotFound`

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -119,7 +119,7 @@ class EmoteBoardService(BaseService):
 
         posts = await self.bot.emote_board_route.get_posts(event.guild_id, event.message_id)
 
-        post_boards = {}
+        post_boards: list[tuple[EmoteBoardPost, EmoteBoard]] = []
 
         for post in posts:
             board = await self.bot.emote_board_route.get_emote_board(
@@ -131,9 +131,9 @@ class EmoteBoardService(BaseService):
                     board=post.name,
                 )
                 continue
-            post_boards[post] = board
+            post_boards.append((post, board))
 
-        for post, board in post_boards.items():
+        for post, emote_board in post_boards:
             for channel_id, message_id in post.channel_message_ids.items():
                 try:
                     if not (channel := guild.get_channel_or_thread(channel_id)):
@@ -142,7 +142,7 @@ class EmoteBoardService(BaseService):
                     assert isinstance(channel, discord.abc.Messageable)
                     embed_msg = await channel.fetch_message(message_id)
                     embed = await self._as_embed(
-                        message, board.reaction_threshold, len(post.reactions), board.emote
+                        message, emote_board.reaction_threshold, len(post.reactions), emote_board.emote
                     )
                     await embed_msg.edit(embed=embed)
                 except NotFound:  # Skips over the item if fetch_message() raises `NotFound`

--- a/ClemBot.Bot/bot/services/message_handling_service.py
+++ b/ClemBot.Bot/bot/services/message_handling_service.py
@@ -297,9 +297,6 @@ class MessageHandlingService(BaseService):
 
     @BaseService.listener(Events.on_message_delete)
     async def on_message_delete(self, message: discord.Message) -> None:
-        if not message.guild:
-            return
-
         log.info(
             "Uncached message deleted in #{channel} by {author}: {content}",
             channel=serializers.log_channel(message.channel),
@@ -331,9 +328,6 @@ class MessageHandlingService(BaseService):
 
     @BaseService.listener(Events.on_raw_message_delete)
     async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
-        if not payload.guild_id:
-            return
-
         message = await self.bot.message_route.get_message(payload.message_id)
         channel = self.bot.get_channel(payload.channel_id)
 

--- a/ClemBot.Bot/bot/services/message_handling_service.py
+++ b/ClemBot.Bot/bot/services/message_handling_service.py
@@ -205,6 +205,10 @@ class MessageHandlingService(BaseService):
     # noinspection PyArgumentList
     @BaseService.listener(Events.on_raw_message_edit)
     async def on_raw_message_edit(self, payload: discord.RawMessageUpdateEvent) -> None:
+        # ignore any cached messages - this will be handled by on_message_edit instead
+        if payload.cached_message:
+            return
+
         message = await self.bot.message_route.get_message(payload.message_id)
         channel = self.bot.get_channel(payload.channel_id)
 
@@ -293,6 +297,9 @@ class MessageHandlingService(BaseService):
 
     @BaseService.listener(Events.on_message_delete)
     async def on_message_delete(self, message: discord.Message) -> None:
+        if not message.guild:
+            return
+
         log.info(
             "Uncached message deleted in #{channel} by {author}: {content}",
             channel=serializers.log_channel(message.channel),
@@ -324,6 +331,9 @@ class MessageHandlingService(BaseService):
 
     @BaseService.listener(Events.on_raw_message_delete)
     async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
+        if not payload.guild_id:
+            return
+
         message = await self.bot.message_route.get_message(payload.message_id)
         channel = self.bot.get_channel(payload.channel_id)
 


### PR DESCRIPTION
This pull request resolves the following issues:
- Emoteboard leaderboard command, "Reactions Received" is inaccurate.
- `TypeError: unhashable type: 'EmoteBoardPost'`
- Message handling service produces duplicate log entries on message edit.
- Message delete event does not take into account DMs.

Resolves #857.
Resolves #859.
Resolves #860.