### PR TITLE
Fix: Check and/or Insert Bot Messages in EmoteBoard Service

### DIFF
--- a/ClemBot.Api/ClemBot.Api.Core/Features/Messages/Bot/Create.cs
+++ b/ClemBot.Api/ClemBot.Api.Core/Features/Messages/Bot/Create.cs
@@ -1,16 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading;
-using System.Threading.Tasks;
-using ClemBot.Api.Common.Utilities;
 using ClemBot.Api.Data.Contexts;
 using ClemBot.Api.Data.Models;
 using ClemBot.Api.Services.Caching.Channels.Models;
 using ClemBot.Api.Services.Caching.Guilds.Models;
 using ClemBot.Api.Services.Caching.Users.Models;
-using FluentValidation;
-using MediatR;
 using NodaTime.Text;
 
 namespace ClemBot.Api.Core.Features.Messages.Bot;

--- a/ClemBot.Bot/bot/api/message_route.py
+++ b/ClemBot.Bot/bot/api/message_route.py
@@ -1,4 +1,5 @@
 import typing as t
+from datetime import datetime
 
 from bot.api.api_client import ApiClient
 from bot.api.base_route import BaseRoute
@@ -16,6 +17,7 @@ class MessageRoute(BaseRoute):
         guild_id: int,
         author_id: int,
         channel_id: int,
+        time: datetime,
         **kwargs: t.Any,
     ) -> None:
         json = {
@@ -26,6 +28,7 @@ class MessageRoute(BaseRoute):
                     "GuildId": guild_id,
                     "UserId": author_id,
                     "ChannelId": channel_id,
+                    "Time": time.strftime("%Y-%m-%dT%H:%M:%S.%f"),
                 }
             ]
         }

--- a/ClemBot.Bot/bot/services/emote_board_service.py
+++ b/ClemBot.Bot/bot/services/emote_board_service.py
@@ -84,6 +84,20 @@ class EmoteBoardService(BaseService):
 
         post = await self.bot.emote_board_route.get_post_from_board(guild, message, board)
 
+        # if the user is a bot, it's very likely we did not store their message in the db...
+        if message.author.bot:
+            stored_message = await self.bot.message_route.get_message(message.id)
+            if stored_message is None:
+                await self.bot.message_route.create_message(
+                    message.id,
+                    message.content,
+                    guild.id,
+                    message.author.id,
+                    channel.id,
+                    message.created_at,
+                    raise_on_error=True,
+                )
+
         if not post:
             await self._create_post(board, message, users)
             return


### PR DESCRIPTION
- Removed unused using directives in `Messages/Bot/Create.cs`
- On creation of an emote board post, the emote board service now checks if the user sending the message is a bot and if the message sent exists inside of the database. If it does not, it will insert the message into the database before creating the emote board post.
- Added `time: datetime` as a parameter for `create_message()` in `message_route.py`, as the API expects it in the payload.